### PR TITLE
Update reactor display name in reactions on profile edit

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -10,7 +10,17 @@ const YOUTUBE_API_URL = 'https://www.googleapis.com/youtube/v3/videos';
 const YOUTUBE_TIMEOUT_MS = 8000;
 
 function getYoutubeId(data) {
-  const candidates = [data?.youtubeId, data?.youtube?.id];
+  const candidates = [data?.youtubeId, data?.youtube?.id, data?.reactionVideoId];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function getOriginalYoutubeId(data) {
+  const candidates = [data?.originalVideoId, data?.originalYoutube?.id, data?.originalYoutube?.meta?.videoId];
   for (const candidate of candidates) {
     if (typeof candidate === 'string' && candidate.trim()) {
       return candidate.trim();
@@ -55,6 +65,21 @@ function shouldEnrich(afterData, beforeData, youtubeId) {
   const idChanged = Boolean(beforeData && beforeId && beforeId !== youtubeId);
   const metaIdMismatch = Boolean(meta?.videoId && meta.videoId !== youtubeId);
   const missingInitialMeta = !metaComplete && !afterData?.lastEnrichedAt;
+
+  return idChanged || metaIdMismatch || stale || missingInitialMeta;
+}
+
+function shouldEnrichOriginal(afterData, beforeData, youtubeId) {
+  if (!youtubeId) return false;
+
+  const meta = afterData?.originalYoutube?.meta;
+  const metaComplete = isMetaComplete(meta, youtubeId);
+  const stale = isStale(afterData?.originalYoutube?.lastEnrichedAt);
+
+  const beforeId = getOriginalYoutubeId(beforeData);
+  const idChanged = Boolean(beforeData && beforeId && beforeId !== youtubeId);
+  const metaIdMismatch = Boolean(meta?.videoId && meta.videoId !== youtubeId);
+  const missingInitialMeta = !metaComplete && !afterData?.originalYoutube?.lastEnrichedAt;
 
   return idChanged || metaIdMismatch || stale || missingInitialMeta;
 }
@@ -149,25 +174,13 @@ function compactMeta(meta) {
   return cleaned;
 }
 
-async function enrichReaction(snapshot, beforeData) {
-  const afterData = snapshot.data();
-  if (!afterData) return;
-
-  const youtubeId = getYoutubeId(afterData);
-  if (!youtubeId) return;
-  if (!shouldEnrich(afterData, beforeData, youtubeId)) return;
-
-  logger.info('Enriching YouTube metadata', { reactionId: snapshot.id, youtubeId });
-
-  const response = await fetchYoutubeMeta(youtubeId);
-  if (!response) return;
-
-  const snippet = response.snippet || {};
-  const contentDetails = response.contentDetails || {};
+function buildMetaFromResponse(response, youtubeId) {
+  const snippet = response?.snippet || {};
+  const contentDetails = response?.contentDetails || {};
   const durationSeconds = parseIsoDurationToSeconds(contentDetails.duration);
   const thumbnail = pickLargestThumbnail(snippet.thumbnails);
 
-  const meta = compactMeta({
+  return compactMeta({
     videoId: youtubeId,
     title: snippet.title,
     description: snippet.description,
@@ -175,14 +188,64 @@ async function enrichReaction(snapshot, beforeData) {
     publishedAt: snippet.publishedAt,
     durationSeconds
   });
+}
 
-  await snapshot.ref.set(
-    {
-      youtube: { meta },
-      lastEnrichedAt: FieldValue.serverTimestamp()
-    },
-    { merge: true }
-  );
+async function enrichReaction(snapshot, beforeData) {
+  const afterData = snapshot.data();
+  if (!afterData) return;
+
+  const reactionYoutubeId = getYoutubeId(afterData);
+  const originalYoutubeId = getOriginalYoutubeId(afterData);
+  const shouldEnrichReaction = reactionYoutubeId && shouldEnrich(afterData, beforeData, reactionYoutubeId);
+  const shouldEnrichOriginalMeta = originalYoutubeId && shouldEnrichOriginal(afterData, beforeData, originalYoutubeId);
+
+  if (!shouldEnrichReaction && !shouldEnrichOriginalMeta) return;
+
+  logger.info('Enriching YouTube metadata', {
+    reactionId: snapshot.id,
+    reactionYoutubeId,
+    originalYoutubeId,
+    shouldEnrichReaction,
+    shouldEnrichOriginal: shouldEnrichOriginalMeta
+  });
+
+  let reactionResponse = null;
+  let originalResponse = null;
+
+  if (shouldEnrichReaction) {
+    reactionResponse = await fetchYoutubeMeta(reactionYoutubeId);
+  }
+
+  if (shouldEnrichOriginalMeta) {
+    if (originalYoutubeId === reactionYoutubeId && reactionResponse) {
+      originalResponse = reactionResponse;
+    } else {
+      originalResponse = await fetchYoutubeMeta(originalYoutubeId);
+    }
+  }
+
+  const updates = {};
+  if (reactionResponse) {
+    const meta = buildMetaFromResponse(reactionResponse, reactionYoutubeId);
+    if (Object.keys(meta).length > 0) {
+      updates.youtube = { meta };
+      updates.lastEnrichedAt = FieldValue.serverTimestamp();
+    }
+  }
+
+  if (originalResponse) {
+    const meta = buildMetaFromResponse(originalResponse, originalYoutubeId);
+    if (Object.keys(meta).length > 0) {
+      updates.originalYoutube = {
+        meta,
+        lastEnrichedAt: FieldValue.serverTimestamp()
+      };
+    }
+  }
+
+  if (Object.keys(updates).length === 0) return;
+
+  await snapshot.ref.set(updates, { merge: true });
 }
 
 export const enrichReactionYoutubeOnCreate = onDocumentCreated('reactions/{id}', async (event) => {

--- a/scripts/enrich-youtube.js
+++ b/scripts/enrich-youtube.js
@@ -75,6 +75,16 @@ function getYoutubeId(data) {
   return null;
 }
 
+function getOriginalYoutubeId(data) {
+  const candidates = [data?.originalVideoId, data?.originalYoutube?.id, data?.originalYoutube?.meta?.videoId];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
 function toDate(value) {
   if (!value) return null;
   if (value instanceof Date) return value;
@@ -180,31 +190,13 @@ function compactMeta(meta) {
   return cleaned;
 }
 
-async function enrichDoc(doc) {
-  const data = doc.data();
-  const youtubeId = getYoutubeId(data);
-  if (!youtubeId) return { updated: false, reason: 'missing-youtube-id' };
-
-  const meta = data?.youtube?.meta;
-  if (isMetaComplete(meta, youtubeId)) {
-    return { updated: false, reason: 'meta-complete' };
-  }
-
-  if (!isStale(data?.lastEnrichedAt) && meta) {
-    return { updated: false, reason: 'meta-fresh' };
-  }
-
-  const response = await fetchYoutubeMeta(youtubeId);
-  if (!response) {
-    return { updated: false, reason: 'youtube-fetch-failed' };
-  }
-
-  const snippet = response.snippet || {};
-  const contentDetails = response.contentDetails || {};
+function buildMetaFromResponse(response, youtubeId) {
+  const snippet = response?.snippet || {};
+  const contentDetails = response?.contentDetails || {};
   const durationSeconds = parseIsoDurationToSeconds(contentDetails.duration);
   const thumbnail = pickLargestThumbnail(snippet.thumbnails);
 
-  const newMeta = compactMeta({
+  return compactMeta({
     videoId: youtubeId,
     title: snippet.title,
     description: snippet.description,
@@ -212,14 +204,69 @@ async function enrichDoc(doc) {
     publishedAt: snippet.publishedAt,
     durationSeconds
   });
+}
 
-  await doc.ref.set(
-    {
-      youtube: { meta: newMeta },
-      lastEnrichedAt: admin.firestore.FieldValue.serverTimestamp()
-    },
-    { merge: true }
-  );
+async function enrichDoc(doc) {
+  const data = doc.data();
+  const youtubeId = getYoutubeId(data);
+  const originalYoutubeId = getOriginalYoutubeId(data);
+
+  if (!youtubeId && !originalYoutubeId) {
+    return { updated: false, reason: 'missing-youtube-id' };
+  }
+
+  const meta = data?.youtube?.meta;
+  const originalMeta = data?.originalYoutube?.meta;
+  const reactionNeedsUpdate =
+    Boolean(youtubeId) && (!isMetaComplete(meta, youtubeId) && (isStale(data?.lastEnrichedAt) || !meta));
+  const originalNeedsUpdate =
+    Boolean(originalYoutubeId) &&
+    (!isMetaComplete(originalMeta, originalYoutubeId) &&
+      (isStale(data?.originalYoutube?.lastEnrichedAt) || !originalMeta));
+
+  if (!reactionNeedsUpdate && !originalNeedsUpdate) {
+    return { updated: false, reason: 'meta-fresh' };
+  }
+
+  let reactionResponse = null;
+  let originalResponse = null;
+
+  if (reactionNeedsUpdate) {
+    reactionResponse = await fetchYoutubeMeta(youtubeId);
+  }
+
+  if (originalNeedsUpdate) {
+    if (originalYoutubeId === youtubeId && reactionResponse) {
+      originalResponse = reactionResponse;
+    } else {
+      originalResponse = await fetchYoutubeMeta(originalYoutubeId);
+    }
+  }
+
+  const updates = {};
+  if (reactionResponse) {
+    const newMeta = buildMetaFromResponse(reactionResponse, youtubeId);
+    if (Object.keys(newMeta).length > 0) {
+      updates.youtube = { meta: newMeta };
+      updates.lastEnrichedAt = admin.firestore.FieldValue.serverTimestamp();
+    }
+  }
+
+  if (originalResponse) {
+    const newMeta = buildMetaFromResponse(originalResponse, originalYoutubeId);
+    if (Object.keys(newMeta).length > 0) {
+      updates.originalYoutube = {
+        meta: newMeta,
+        lastEnrichedAt: admin.firestore.FieldValue.serverTimestamp()
+      };
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { updated: false, reason: 'youtube-fetch-failed' };
+  }
+
+  await doc.ref.set(updates, { merge: true });
 
   return { updated: true, reason: 'updated' };
 }

--- a/src/lib/components/Video/CreatorDetails.svelte
+++ b/src/lib/components/Video/CreatorDetails.svelte
@@ -13,6 +13,8 @@
     export let isUsersOwnVideo;
     export let reactionVideoId;
     export let originalVideoId;
+    export let originalVideoDescription;
+    export let reactionVideoDescription;
 
     const createAvatarPlaceholder = (_name) => '/by-icon.svg';
 
@@ -24,10 +26,29 @@
         let viewerData;
         $: viewerData = $userExtraDataStore?.userExtraData;
     $: canUseActions = Boolean(viewerData) && !isUsersOwnVideo;
+
+    let isOriginalDescriptionExpanded = false;
+    let isReactionDescriptionExpanded = false;
+
+    $: showOriginalDescriptionToggle =
+        typeof originalVideoDescription === 'string' && originalVideoDescription.trim().length > 200;
+    $: showReactionDescriptionToggle =
+        typeof reactionVideoDescription === 'string' && reactionVideoDescription.trim().length > 200;
+
+    $: showOriginalActions = Boolean(originalVideoId);
+    $: showReactionActions = Boolean(reactionVideoId) || Boolean(canUseActions);
 </script>
 
 <section class="details-grid" aria-label="Creator details">
-    <article class="column" aria-labelledby="original-heading">
+    <article class="column original" aria-labelledby="original-heading">
+        {#if showOriginalActions}
+            <div class="header-actions">
+                {#if originalVideoId}
+                    <RateVideo videoId={originalVideoId} />
+                {/if}
+            </div>
+        {/if}
+
         <header class="column-header">
             <h2 id="original-heading" class="video-heading">
                 {#if originalVideoTitle}
@@ -63,14 +84,48 @@
             </div>
         </div>
 
-        <div class="header-actions">
-            {#if originalVideoId}
-                <RateVideo videoId={originalVideoId} />
-            {/if}
-        </div>
+        {#if originalVideoDescription}
+            <div class="video-description">
+                <p
+                    id="original-description"
+                    class={`description-text ${isOriginalDescriptionExpanded || !showOriginalDescriptionToggle ? 'expanded' : 'clamped'}`}
+                >
+                    {originalVideoDescription}
+                </p>
+                {#if showOriginalDescriptionToggle}
+                    <button
+                        type="button"
+                        class="description-toggle"
+                        aria-expanded={isOriginalDescriptionExpanded}
+                        aria-controls="original-description"
+                        on:click={() => (isOriginalDescriptionExpanded = !isOriginalDescriptionExpanded)}
+                    >
+                        {isOriginalDescriptionExpanded ? 'Show less' : 'Show more'}
+                    </button>
+                {/if}
+            </div>
+        {/if}
     </article>
 
-    <article class="column" aria-labelledby="reaction-heading">
+    <article class="column reaction" aria-labelledby="reaction-heading">
+        {#if showReactionActions}
+            <div class="header-actions">
+                {#if reactionVideoId}
+                    <RateVideo videoId={reactionVideoId} />
+                {/if}
+                {#if canUseActions}
+                    <BookmarkManagement slug={pageSlug} />
+                {/if}
+                {#if canUseActions && reactionVideoAuthor}
+                    <FollowManagement
+                        reactionCreator={reactionVideoAuthor}
+                        {reactorId}
+                        follows={viewerData?.follows}
+                    />
+                {/if}
+            </div>
+        {/if}
+
         <header class="column-header">
             <h2 id="reaction-heading" class="video-heading">
                 {#if reactionVideoTitle}
@@ -106,21 +161,27 @@
             </div>
         </div>
 
-        <div class="header-actions">
-            {#if reactionVideoId}
-                <RateVideo videoId={reactionVideoId} />
-            {/if}
-            {#if canUseActions}
-                <BookmarkManagement slug={pageSlug} />
-            {/if}
-            {#if canUseActions && reactionVideoAuthor}
-                <FollowManagement
-                    reactionCreator={reactionVideoAuthor}
-                    {reactorId}
-                    follows={viewerData?.follows}
-                />
-            {/if}
-        </div>
+        {#if reactionVideoDescription}
+            <div class="video-description">
+                <p
+                    id="reaction-description"
+                    class={`description-text ${isReactionDescriptionExpanded || !showReactionDescriptionToggle ? 'expanded' : 'clamped'}`}
+                >
+                    {reactionVideoDescription}
+                </p>
+                {#if showReactionDescriptionToggle}
+                    <button
+                        type="button"
+                        class="description-toggle"
+                        aria-expanded={isReactionDescriptionExpanded}
+                        aria-controls="reaction-description"
+                        on:click={() => (isReactionDescriptionExpanded = !isReactionDescriptionExpanded)}
+                    >
+                        {isReactionDescriptionExpanded ? 'Show less' : 'Show more'}
+                    </button>
+                {/if}
+            </div>
+        {/if}
     </article>
 </section>
 
@@ -128,8 +189,9 @@
     .details-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 1.75rem;
-        padding: 1.5rem;
+        align-items: start;
+        gap: 1.25rem;
+        padding: 1.25rem;
         border-radius: 1rem;
         background: rgba(12, 15, 21, 0.72);
         border: 1px solid rgba(255, 255, 255, 0.05);
@@ -137,23 +199,18 @@
     }
 
     .column {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        grid-template-areas:
-            'heading actions'
-            'identity identity';
+        display: flex;
+        flex-direction: column;
         gap: 1.25rem;
     }
 
     .column-header {
-        grid-area: heading;
         min-width: 0;
     }
 
     .header-actions {
-        grid-area: actions;
-        justify-self: end;
-        align-self: start;
+        align-self: flex-start;
+        justify-content: flex-start;
     }
 
     .video-heading {
@@ -166,10 +223,49 @@
     }
 
     .identity {
-        grid-area: identity;
         display: flex;
         align-items: flex-start;
         gap: 1rem;
+    }
+
+    .video-description {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .description-text {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: rgba(199, 203, 215, 0.85);
+        word-break: break-word;
+        white-space: pre-line;
+    }
+
+    .description-text.clamped {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 5;
+        overflow: hidden;
+    }
+
+    .description-toggle {
+        align-self: flex-start;
+        border: none;
+        background: transparent;
+        padding: 0;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: rgba(92, 178, 255, 0.9);
+        cursor: pointer;
+    }
+
+    .description-toggle:hover,
+    .description-toggle:focus-visible {
+        color: rgba(130, 197, 255, 0.95);
+        outline: none;
     }
 
     .identity img {
@@ -211,7 +307,7 @@
     .header-actions {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.4rem;
         flex-wrap: wrap;
     }
 
@@ -241,26 +337,62 @@
         height: 1.1rem;
     }
 
-    @media (max-width: 768px) {
+    @media (min-width: 769px) {
         .details-grid {
-            padding: 1.25rem;
-            gap: 1.25rem;
+            padding: 1.5rem;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            grid-template-rows: auto auto auto auto;
+            column-gap: 1.75rem;
+            row-gap: 1.25rem;
         }
 
         .column {
-            grid-template-columns: 1fr;
-            grid-template-areas:
-                'heading'
-                'identity'
-                'actions';
+            display: contents;
+        }
+
+        .column.original .header-actions {
+            grid-column: 1;
+            grid-row: 1;
+        }
+
+        .column.original .column-header {
+            grid-column: 1;
+            grid-row: 2;
+        }
+
+        .column.original .identity {
+            grid-column: 1;
+            grid-row: 3;
+        }
+
+        .column.original .video-description {
+            grid-column: 1;
+            grid-row: 4;
+        }
+
+        .column.reaction .header-actions {
+            grid-column: 2;
+            grid-row: 1;
+        }
+
+        .column.reaction .column-header {
+            grid-column: 2;
+            grid-row: 2;
+        }
+
+        .column.reaction .identity {
+            grid-column: 2;
+            grid-row: 3;
+        }
+
+        .column.reaction .video-description {
+            grid-column: 2;
+            grid-row: 4;
         }
 
         .header-actions {
             justify-self: start;
-        }
-
-        .header-actions {
-            gap: 0.4rem;
+            gap: 0.5rem;
         }
     }
 </style>

--- a/src/lib/components/reaction/AttributionBlock.svelte
+++ b/src/lib/components/reaction/AttributionBlock.svelte
@@ -299,7 +299,7 @@
 
 {#if !shouldHideAttribution}
   <section
-    class="flex items-center justify-between gap-3 rounded-xl border border-border-strong/20 bg-surface/60 px-3 py-2 text-xs text-text-muted shadow-surface/40 backdrop-blur"
+    class="flex flex-col gap-3 rounded-xl border border-border-strong/20 bg-surface/60 px-3 py-2 text-xs text-text-muted shadow-surface/40 backdrop-blur sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
     aria-label="Attribution"
     data-testid="attribution-block"
     data-debug-channel-handle={channelHandle}
@@ -321,24 +321,28 @@
     />
 
     {#if canShowClaimControls}
-      <AttributionClaimControls
-        showLoginCta={showLoginCta}
-        showLookupCta={showLookupCta}
-        showPendingCta={showPendingCta}
-        showReviewedCta={showReviewedCta}
-        showClaimCta={showClaimCta}
-        reviewedClaimLabel={reviewedClaimLabel}
-        showInfoTip={showInfoTip}
-        onLogin={() => goto('/login')}
-        onClaim={openClaimModal}
-      />
+      <div class="flex w-full items-center sm:w-auto sm:justify-end">
+        <AttributionClaimControls
+          showLoginCta={showLoginCta}
+          showLookupCta={showLookupCta}
+          showPendingCta={showPendingCta}
+          showReviewedCta={showReviewedCta}
+          showClaimCta={showClaimCta}
+          reviewedClaimLabel={reviewedClaimLabel}
+          showInfoTip={showInfoTip}
+          onLogin={() => goto('/login')}
+          onClaim={openClaimModal}
+        />
+      </div>
     {/if}
     {#if claimLookupState === 'error' && claimLookupError}
-      <p class="mt-1 text-[0.7rem] text-red-400">{claimLookupError}</p>
+      <p class="mt-1 text-[0.7rem] text-red-400 sm:w-full">{claimLookupError}</p>
     {/if}
   </section>
 {:else if isChannelVerified}
-  <AttributionVerifiedBadge />
+  <div class="flex justify-center">
+    <AttributionVerifiedBadge />
+  </div>
 {/if}
 
 <AttributionClaimModal

--- a/src/lib/components/reaction/AttributionPrimaryInfo.svelte
+++ b/src/lib/components/reaction/AttributionPrimaryInfo.svelte
@@ -12,28 +12,32 @@
   export let isChannelVerified = false;
 </script>
 
-<div class="min-w-0 flex items-center gap-2 text-text-muted">
-  <span class="shrink-0">{primaryPrefix}:</span>
-  {#if primaryHref}
-    <a
-      class="max-w-[14rem] truncate text-text-primary transition hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:max-w-[20rem]"
-      href={primaryHref}
-      title={primaryName}
-      aria-label={primaryLinkLabel}
-      target={primaryLinkTarget}
-      rel={primaryLinkRel}
-    >
-      {primaryName}
-    </a>
-  {:else}
-    <span class="max-w-[14rem] truncate text-text-primary sm:max-w-[20rem]" title={primaryName}>
-      {primaryName}
-    </span>
-  {/if}
+<div class="min-w-0 flex flex-col gap-1 text-text-muted sm:flex-row sm:items-center sm:gap-2">
+  <div class="min-w-0 flex items-center gap-2">
+    <span class="shrink-0">{primaryPrefix}:</span>
+    {#if primaryHref}
+      <a
+        class="max-w-[14rem] truncate text-text-primary transition hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:max-w-[20rem]"
+        href={primaryHref}
+        title={primaryName}
+        aria-label={primaryLinkLabel}
+        target={primaryLinkTarget}
+        rel={primaryLinkRel}
+      >
+        {primaryName}
+      </a>
+    {:else}
+      <span class="max-w-[14rem] truncate text-text-primary sm:max-w-[20rem]" title={primaryName}>
+        {primaryName}
+      </span>
+    {/if}
+  </div>
 
-  {#if isChannelVerified}
-    <AttributionVerifiedBadge />
-  {/if}
+  <div class="flex flex-wrap items-center justify-center gap-2 sm:justify-start sm:gap-1">
+    {#if isChannelVerified}
+      <AttributionVerifiedBadge />
+    {/if}
 
-  <AttributionCreatorBadge isVerifiedCreator={isVerifiedCreator} />
+    <AttributionCreatorBadge isVerifiedCreator={isVerifiedCreator} />
+  </div>
 </div>

--- a/src/lib/components/reaction/AttributionVerifiedBadge.svelte
+++ b/src/lib/components/reaction/AttributionVerifiedBadge.svelte
@@ -1,5 +1,5 @@
 <span
-  class="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-emerald-200"
+  class="inline-flex items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[0.65rem] font-semibold uppercase leading-none tracking-wide text-emerald-200"
   aria-label="Verified channel"
 >
   Verified channel

--- a/src/lib/composables/useTwinPlayers.ts
+++ b/src/lib/composables/useTwinPlayers.ts
@@ -82,8 +82,10 @@ type TwinPlayersState = {
   reactionVideoAuthor?: string;
   reactorDisplayName?: string;
   reactionVideoTitle?: string;
+  reactionVideoDescription?: string;
   originalVideoAuthor?: string;
   originalVideoTitle?: string;
+  originalVideoDescription?: string;
   originalVideoId?: string;
   reactorId?: string;
   youtubePlaylistId?: string;
@@ -327,6 +329,8 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
     reactionVideoAuthor: undefined,
     reactorDisplayName: undefined,
     reactionVideoTitle: undefined,
+    reactionVideoDescription: undefined,
+    originalVideoDescription: undefined,
     originalVideoId: undefined,
     reactorId: undefined,
     youtubePlaylistId: undefined,
@@ -2052,6 +2056,22 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
     const viewerDisplayName = typeof data?.displayName === 'string' ? data.displayName.trim() : '';
     const resolvedReactorDisplayName =
       rawReactorDisplayName || (reactionData?.reactorId === userId ? viewerDisplayName : '');
+    const reactionVideoDescription =
+      (typeof reactionData?.reactionVideoDescription === 'string'
+        ? reactionData.reactionVideoDescription.trim()
+        : '') ||
+      (typeof reactionData?.youtube?.meta?.description === 'string'
+        ? reactionData.youtube.meta.description.trim()
+        : '') ||
+      undefined;
+    const originalVideoDescription =
+      (typeof reactionData?.originalVideoDescription === 'string'
+        ? reactionData.originalVideoDescription.trim()
+        : '') ||
+      (typeof reactionData?.originalYoutube?.meta?.description === 'string'
+        ? reactionData.originalYoutube.meta.description.trim()
+        : '') ||
+      undefined;
 
     updateState({
       isPublished: reactionData.isPublished,
@@ -2074,8 +2094,10 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       reactionVideoAuthor: reactionData?.reactionVideoAuthor,
       reactorDisplayName: resolvedReactorDisplayName || undefined,
       reactionVideoTitle: reactionData?.reactionVideoTitle,
+      reactionVideoDescription,
       originalVideoAuthor: reactionData?.originalVideoAuthor,
       originalVideoTitle: reactionData?.originalVideoTitle,
+      originalVideoDescription,
       youtubePlaylistId,
       offsetStartTime,
       reactionFinishTime,

--- a/src/lib/helpers/firebase.js
+++ b/src/lib/helpers/firebase.js
@@ -13,7 +13,8 @@ import {
     orderBy,
     or,
     limit,
-    startAfter
+    startAfter,
+    writeBatch
 } from "firebase/firestore/lite";
 import {
     getAuth,
@@ -870,6 +871,45 @@ export async function updateDisplayNameHelper(user, displayName) {
         throw error;
     }
 }
+
+export const updateReactorDisplayNameForUser = async ({ userId, displayName }) => {
+    const trimmedName = typeof displayName === 'string' ? displayName.trim() : '';
+    if (!userId || !trimmedName) {
+        return { updated: 0, skipped: true };
+    }
+    try {
+        const reactionsCollection = createCollection(
+            db,
+            COLLECTION_REACTION_BINOMES,
+            'updateReactorDisplayNameForUser'
+        );
+        const queryRef = query(reactionsCollection, where('reactorId', '==', userId));
+        const snapshot = await getDocs(queryRef);
+        if (snapshot.empty) {
+            return { updated: 0 };
+        }
+
+        const docs = snapshot.docs;
+        const batchSize = 500;
+        let updated = 0;
+
+        for (let i = 0; i < docs.length; i += batchSize) {
+            const batch = writeBatch(db);
+            const chunk = docs.slice(i, i + batchSize);
+            chunk.forEach((docSnap) => {
+                const docRef = doc(reactionsCollection, docSnap.id);
+                batch.update(docRef, { reactorDisplayName: trimmedName });
+            });
+            await batch.commit();
+            updated += chunk.length;
+        }
+
+        return { updated };
+    } catch (error) {
+        console.error('Error updating reactor display name in reactions:', error);
+        return { updated: 0, error: true };
+    }
+};
 export async function updatePhotoHelper(user, photoURL) {
     try {
         await updateProfile(user, { photoURL });

--- a/src/routes/account/edit/+page.svelte
+++ b/src/routes/account/edit/+page.svelte
@@ -3,6 +3,7 @@
     import {
         auth,
         updateDisplayNameHelper,
+        updateReactorDisplayNameForUser,
         updateEmailHelper,
         updatePasswordHelper,
         reauthenticateUserHelper
@@ -31,6 +32,7 @@
   
     const updateDisplayName = async () => {
       await updateDisplayNameHelper(user, newName);
+      await updateReactorDisplayNameForUser({ userId: user?.uid, displayName: newName });
       showToast('Profile updated successfully', TOASTS.SUCCESS);
     //   location.reload();
     };

--- a/src/routes/playlist/[slug]/+page.svelte
+++ b/src/routes/playlist/[slug]/+page.svelte
@@ -264,15 +264,17 @@
         originalVideoAuthor={$state.originalVideoAuthor}
         originalVideoTitle={$state.originalVideoTitle}
         originalVideoId={$state.originalVideoId}
+        originalVideoDescription={$state.originalVideoDescription}
         reactionVideoAuthor={$state.reactionVideoAuthor}
         reactionVideoTitle={$state.reactionVideoTitle}
         reactionVideoId={$state.reactionVideoId}
+        reactionVideoDescription={$state.reactionVideoDescription}
         pageSlug={$state.pageSlug}
         isUsersOwnVideo={$state.isUsersOwnVideo}
         reactorId={$state.reactorId}
         reactorDisplayName={$state.reactorDisplayName}
       />
-      <div class="mt-2">
+      <div class="mt-3 sm:mt-4">
         <AttributionBlock
           reactionVideoAuthor={$state.reactionVideoAuthor}
           reactorDisplayName={$state.reactorDisplayName}

--- a/src/routes/reaction/[slug]/+page.svelte
+++ b/src/routes/reaction/[slug]/+page.svelte
@@ -260,15 +260,17 @@
           originalVideoAuthor={$state.originalVideoAuthor}
           originalVideoTitle={$state.originalVideoTitle}
           originalVideoId={$state.originalVideoId}
+          originalVideoDescription={$state.originalVideoDescription}
           reactionVideoAuthor={$state.reactionVideoAuthor}
           reactionVideoTitle={$state.reactionVideoTitle}
           reactionVideoId={$state.reactionVideoId}
+          reactionVideoDescription={$state.reactionVideoDescription}
           pageSlug={$state.pageSlug}
           isUsersOwnVideo={$state.isUsersOwnVideo}
           reactorId={$state.reactorId}
           reactorDisplayName={$state.reactorDisplayName}
         />
-        <div class="mt-2">
+        <div class="mt-3 sm:mt-4">
           <AttributionBlock
             reactionVideoAuthor={$state.reactionVideoAuthor}
             reactorDisplayName={$state.reactorDisplayName}


### PR DESCRIPTION
Added updateReactorDisplayNameForUser helper to batch update the reactorDisplayName field in reactions when a user changes their display name. Integrated this helper into the account edit page to ensure consistency across user-related data.

resolves https://github.com/animyrch/pure-reactions/issues/134 #135 #136