### PR TITLE
fix: show success toast on logout instead of login required message

### DIFF
--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -51,6 +51,7 @@ export async function load({ depends }) {
             }
         }
         if (action === 'logout') {
+            showToast('You have been logged out successfully', TOASTS.SUCCESS, 5000);
             await signOutWrapper();
             currentUser.set({});
             await invalidate('app:auth');


### PR DESCRIPTION
Previously, when users logged out, they would see a 'You need to login' error message instead of a logout confirmation. This was because no success toast was being displayed during the logout process.

This commit adds a success toast message that appears when users successfully log out, providing clear feedback about the action.

Closes #129