### PR TITLE
Replace handlePrivateRoute with goto for redirect

### DIFF
--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -51,10 +51,10 @@ export async function load({ depends }) {
             }
         }
         if (action === 'logout') {
+            goToRoute('/');
             await signOutWrapper();
             currentUser.set({});
             await invalidate('app:auth');
-            await goToRoute('/');
         }
     };
     return {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,15 +9,15 @@
 	import { SORTINGS } from "$lib/constants/sortings";
 	import { userExtraDataStore } from "$lib/stores/userExtraData";
 	import { onMount, onDestroy, tick } from "svelte";
-	import { handlePrivateRoute } from "$lib/helpers/routing";
 	import { isLoggedIn } from "$lib/stores/user";
+	import { goto } from "$app/navigation";
 
 	// Initialize Firebase
 	$: if (
 		$page.url.searchParams.get("sortBy") === SORTINGS.FOLLOWING &&
 		!$isLoggedIn
 	) {
-		handlePrivateRoute();
+		goto(`/?sortBy=${SORTINGS.NEW}`);
 	}
 	let reactions = [];
 	let isLoading = false;


### PR DESCRIPTION
Replaces the use of handlePrivateRoute with SvelteKit's goto function to redirect unauthenticated users from the 'following' sort to the 'new' sort. This streamlines the redirection logic and removes an unnecessary error message on logout
#resolves #129