### PR TITLE
Add GDPR data export API, UI and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Pure Reactions — AI Agent Instructions (Cinematic Authentic)
+
+> **Purpose:** Provide a single-source, action-oriented instruction set for any AI agent (design assistant, frontend helper, content curator) working on the visual identity and UI/UX of **purereactions.com** under the *Cinematic Authentic* visual language.
+
+---
+
+## 1 — Agent mission
+
+* **Primary mission:** Help create, maintain, and evolve a cinematic-authentic visual identity that highlights real emotion in reaction videos while ensuring accessibility, performance, and developer handoff readiness.
+* **Secondary mission:** Produce developer-ready deliverables (CSS tokens, component examples, motion specs), content guidance (image selection rules, caption tone), and QA checks that preserve the brand language.
+
+---
+
+## 2 — Persona & Tone
+
+The agent should behave like a calm, experienced art director who also understands frontend engineering.
+
+* **Voice:** succinct, professional, approachable. No marketing fluff.
+* **Attitude:** helpful, decisive, minimal hesitation.
+* **When giving options:** recommend a single best choice with reasoning and provide **1 prioritized** alternative if applicable.
+
+---
+
+## 3 — Visual language summary (one-liner)
+
+**Real people. Real emotions. Shot like cinema.**
+
+---
+
+## 4 — Core principles (rules the agent must follow)
+
+1. **Emotion-first:** prioritize faces and expressions in every visual decision.
+2. **Cinematic framing:** prefer 16:9 aspect emphasis, close-ups, and generous negative space.
+3. **Palette and breakpoints:** design mobile-first and dark-mode-first UI with carefully chosen accent colors.
+4. **Subtle motion:** prefer slow fades, cross-dissolves, slight zoom/focus pulls. No bouncy/childlike motion.
+5. **Respect skin tones:** never apply color grading that distorts skin tones; aim for naturalness.
+6. **Accessibility:** meet WCAG AA for contrast on key text and interactive elements.
+7. **Performance-aware:** assets must be optimized for web (responsive sizes, compressed formats, lazy load).
+8. **Avoid clickbait:** no sensational UI patterns (e.g., fake counters, misleading overlays).
+
+---
+
+## 8 — Decision heuristics (how the agent chooses between options)
+
+1. **Technical choices:** prefer Tailwind whenever possible.
+2. **Accessibility:** prefer the option that achieves at least WCAG AA for text over aesthetic preference.
+3. **Simplicity:** prefer simpler implementation if visual impact is similar.
+4. **Performance:** prefer smaller asset cost for comparable visual quality.
+5. **Emotion signal:** choose the option that better surfaces facial expression (crop, color, contrast).
+
+**Don’t**
+
+* Use heavy, Instagram-like filters that change skin tones.
+* Add loud UI chrome that competes with faces.
+* Propose motion that induces dizziness or is slow to respond.
+
+---
+
+## 10 — Accessibility constraints
+
+* Minimum contrast ratio 4.5:1 for body text, 3:1 for larger headings where applicable.
+* All video cards must be focusable via keyboard and have meaningful `aria-label` with content title and short description.
+* Provide captions/subtitles as metadata if available; provide visible captions option on the player.
+
+---
+
+## 11 — Performance & technical constraints
+
+* Deliver responsive images via `srcset` and WebP where supported.
+* Video thumbnails should have a 16:9 poster at 16:9, 1280×720 max for desktop preview with lower sizes for mobile.
+* Lazy-load below-the-fold thumbnails.
+
+## Core Architecture
+- SvelteKit app targeting Netlify (`svelte.config.js`, `netlify.toml`); `vite.config.js` enables `enhancedImages` for responsive <img> markup.
+- Global layout lives in `src/routes/+layout.svelte`, wiring top navigation, toast host, reduced-motion class toggling, and per-route view transitions.
+- Auth handshake happens in `src/routes/+layout.js` load: wraps Firebase auth helpers, populates `currentUser`, exposes `handleUserAction` to child pages.
+- Routing follows SvelteKit filesystem; key feature pages: `routes/backend/+page.svelte` (recording), `routes/reaction/[slug]/+page.svelte` (playback), `routes/shared/[sessionId]/+page.svelte` (co-watch).
+- Component library under `src/lib/components` splits domain widgets (Video, Search, Navigation) and design primitives under `design-system/`.
+- State shared via writable Svelte stores (`lib/stores`); prefer existing stores (`currentUser`, `userExtraDataStore`, `prefersReducedMotion`, `toasts`) rather than new globals.
+## Developer Workflow
+- Install deps with `npm install`; daily commands: `npm run dev` (local server), `npm run build` (Netlify parity), `npm run lint` (Svelte + JS via eslint).
+- Env vars live in `.env` with `PUBLIC_FIREBASE_*`, `PUBLIC_ALGOLIA_*`, and private `YOUTUBE_API_KEY` and `ALGOLIA_ADMIN_KEY`; see `constants/firebase.js` and `lib/services/search/`.
+- Firebase config uses Firestore Lite + Realtime DB; when adding fields ensure they are serialisable by `updateFirebaseDocument` (no functions).
+- Shared session tooling expects Realtime Database rules that allow the paths under `sharedSessions/`; keep server timestamps via helper functions.
+- Search uses provider abstraction at `lib/services/search/`; never import `algoliasearch` directly in components—use `getSearchProvider()` instead for easy migration.
+## Reaction Pipeline
+- Recording flow (`routes/backend/+page.svelte`) streams YouTube via IFrame API, logs state/volume/playback maps to Firestore using `updateFirebaseDocument`.
+- Timelines accept legacy object maps and new array formats; helpers in `lib/helpers/reaction.js` auto-detect both—preserve compatibility when writing data.
+- Backend page caches current doc id on `window.currentReactionDocumentId`; any update helpers depend on that side-effect—set it before calling `updateFirebaseDocument`.
+- `PlaylistQueue.svelte` and playlist helpers use `createPlaylistDocument`/`addToPlaylistDocument`; reaction playback reads playlist context from query params.
+- Playback page (`routes/reaction/[slug]/+page.svelte`) runs twin YT players via `useTwinPlayers` and syncs the original video from timelines/configs.
+  - **Sync decision logic is pure**: `computeTwinPlayersSyncTick` lives under `src/lib/helpers/` and returns declarative actions + updated tracking.
+  - **Side effects stay in the composable**: apply actions via `applyTwinPlayersSyncActions`, keep guard flags (`changingVolume/changingReactionVolume/changingSpeed`) to avoid feedback loops.
+  - **Scheduling is boundary-aware**: use a `setTimeout`-based scheduler (not a constant `setInterval`) and wake near timeline boundaries + periodically for drift correction.
+  - **Keep timelines sorted**: scheduling looks up the “next boundary” via binary search over `{ t }` arrays.
+  - **Avoid `window.*` in the sync path**: prefer store-held configs/timelines; `window.*` is for legacy/debug surfaces only.
+- Playlist autoplay toggled via cookies in playback page; reuse `loadNextReactionInPlaylist` when extending queue behavior.
+## Shared Sessions & Social
+- Co-watch sessions live in Firebase Realtime DB via `lib/helpers/sharedSession.js`; host updates come from backend recorder, viewers subscribe in `routes/shared/[sessionId]/+page.svelte`.
+- `updateSessionState` automatically stamps `lastUpdated`; call it whenever altering `state`, `currentTime`, `volume`, or `playbackRate`.
+- `userExtraDataStore` mediates bookmarks/follows; always call store methods so UI state stays in sync before Firestore writes (optimistic updates).
+- Private actions should funnel through `handlePrivateRoute` to redirect unauthenticated users and surface a toast.
+## UI System & Accessibility
+- Tailwind theme extends `designTokens` (`lib/constants/designTokens.js`); stick to tokenized colors (`bg-surface`, `text-text-muted`) to honor contrast rules.
+- Cinematic cards/buttons in `lib/components/design-system` bake in hover/motion defaults; prefer composing these over ad-hoc Tailwind stacks.
+- Global styles in `app.pcss` enforce reduced-motion; respect `prefersReducedMotion` store before adding transitions or animations.
+- Toasts use `lib/stores/toast`; to show feedback call `showToast(message, type, duration)` and let `routes/+layout.svelte` render them.
+- Flowbite-Svelte components are available but override their palettes with Tailwind classes so they match the Cinematic Authentic palette.
+## External Integrations
+- YouTube IFrame API is dynamically injected (see playback and shared session pages); bind handlers via global `YT` events and guard against SSR (`typeof window`).
+- Serverless playlist fetcher at `routes/api/youtube/playlist/[id]/+server.js` proxies playlist items; respect quota limits and bubble HTTP failures to the UI.
+- Search is provider-agnostic via `lib/services/search/`; currently uses Algolia but can swap to Meilisearch/Typesense by changing factory. Run `npm run algolia:status` to check index health, `npm run algolia:index` to reindex. See `docs/ALGOLIA_OPERATIONS.md`.
+- Netlify deploy picks up `build/` output; keep adapter-specific assumptions (no Node APIs at runtime) when adding backend logic.
+## Schema Discipline
+- Whenever new objects are created in Firebase, Algolia, or any backend service, add their schema to the schema doc.
+- When manipulating or using existing objects from external services, always refer to the schema doc to avoid hallucinating properties.
+- Keep the `## Version History` section in `docs/SCHEMA_REFERENCE.md` updated whenever schemas change.
+
+## 12 — Logic placement & small-file strategy
+1. **Composables orchestrate** — keep `use*` composables responsible for lifecycle hooks, store wiring, Firebase calls, YT players, and UI helpers. They should stay stateful and thin.
+2. **Helpers stay stateless** — deterministic logic (rounding, map/array conversions, timeline derivations) belongs under `src/lib/helpers/`. Prefer descriptive names (e.g., `twinPlayersTimeline.ts`) so other modules can reuse them without bringing in composable state.
+  - For twin-player sync: keep “what should happen” in helpers (`twinPlayersSyncTick`, `twinPlayersSyncScheduling`) and keep “do it” (player calls, timers, stores) in the composable.
+3. **Split when needed** — if a file grows past ~300 lines or mixes side effects + pure logic, consider extracting the pure parts into a helper. Document the split briefly so future contributors understand where each responsibility lives.
+4. **Name for intent** — favor folder names that imply behavior (`helpers` vs `composables`). When adding new helpers, update `README.md` or documentation comments with the reasoning so the team remembers the standard.
+
+5. **Components present, helpers derive** — components should focus on obtaining data and rendering; move formatting, parsing, label building, and state derivation into helpers. Split independent layout compartments into their own components even if single-use.
+
+## 13 — Browser testing reference (Playwright fixtures)
+* When you run or describe browser tests, use the same reaction slugs and video IDs that the Playwright twin-player suite targets so the experience matches what CI exercises. Those IDs are defined in `tests/fixtures/reactions/*.json` and referenced by `tests/twin-player-basic-sync.spec.js`.
+* Keep the following mapping handy for quick reference and share it when explaining a test scenario to collaborators or the agent:
+  - Basic Sync → Reaction page `/reaction/1PaTrdCMKn6ay7nShHES`, video ID `8-3PahRtgF4`, fixture `tests/fixtures/reactions/twin-basic-sync.json`.
+  - Play Trigger → `/reaction/8O1sPJr6atB0K2CvyItV`, video ID `qg6b4b0FAB4`, fixture `tests/fixtures/reactions/twin-play-trigger.json`.
+  - Volume Stability → `/reaction/Dw3UZ6PqZH37E5pbKmhZ`, video ID `dHh_gt4sBbw`, fixture `tests/fixtures/reactions/twin-volume-stability.json`.
+  - Resume After Config Pause → `/reaction/BUOR5TM6yAHSClCCRvIp`, video ID `GQ_SlNONhx4`, fixture `tests/fixtures/reactions/twin-resume-after-config-pause.json`.

--- a/docs/ACCOUNT_DELETION.md
+++ b/docs/ACCOUNT_DELETION.md
@@ -143,7 +143,7 @@ See [ACCOUNT_DELETION_SETUP.md](./ACCOUNT_DELETION_SETUP.md) for detailed setup 
 ## Future Enhancements
 
 - Grace period (e.g., 30 days to cancel deletion)
-- Data export before deletion (GDPR compliance)
+- Optional pre-delete export reminder in the deletion flow
 - Admin dashboard for monitoring deletion requests
 - Audit log for compliance tracking
 

--- a/docs/GDPR_DATA_EXPORT.md
+++ b/docs/GDPR_DATA_EXPORT.md
@@ -1,0 +1,65 @@
+# GDPR Data Access & Export
+
+## Purpose
+This document describes how Pure Reactions fulfills GDPR data access requests (DSAR) through a self-service export flow. It aligns implementation with documented data mappings and clarifies what is included or excluded.
+
+## Verified Data Map
+
+### Firebase Authentication (Account Profile)
+- **Scope**: Auth user record for the requesting user only.
+- **Fields**: UID, email, emailVerified, displayName, photoURL, phoneNumber, provider data, custom claims, account metadata (creation/sign-in times).
+- **Source**: Firebase Authentication (Admin SDK).
+
+### Firestore (Primary Application Data)
+- **Collections (user-scoped)**:
+  - `userData` (doc ID = userId): bookmarks, follows, optional profile fields, `lastExportAt`.
+  - `reactions`: documents where `reactorId == userId`.
+  - `playlists`: documents where `userId == userId`.
+  - `queues`: documents where `ownerId == userId`.
+  - `youtubeChannelClaims`: documents where `userId == userId`.
+  - `youtubeChannelVerifications`: documents whose channel IDs are referenced by the user’s claims.
+- **Schema reference**: `docs/SCHEMA_REFERENCE.md`.
+
+### Algolia (Search Index)
+- **Index**: `ALGOLIA_REACTIONS_INDEX`.
+- **Scope**: records whose `objectID` matches the user’s reaction document IDs.
+- **Note**: Only published reactions are indexed; missing IDs are listed in the export.
+
+### Firebase Realtime Database (Excluded)
+- **Shared sessions** (`sharedSessions/{sessionId}`) are transient synchronization data and are **not exported**.
+
+## Export Implementation
+- **Endpoint**: `POST /api/account/export`.
+- **Authentication**: Firebase ID token required; userId derived from token only.
+- **Rate limit**: One export per user per 24 hours, enforced via `userData.lastExportAt`.
+- **Determinism**: Export arrays are sorted by document ID / objectID.
+
+## Export Format (JSON)
+Top-level structure:
+- `meta`: exportVersion, generatedAt, userId, counts, excluded categories, and notes.
+- `data.auth`: Firebase Auth profile snapshot.
+- `data.firestore`: grouped Firestore documents.
+- `data.algolia`: search index records and missing object IDs.
+
+## Extraction Limitations
+- **Transient infrastructure logs** (Netlify/CDN/Firebase logs) are not stored for export.
+- **Realtime shared session state** is excluded.
+- **Deleted data** cannot be recovered or exported.
+- **Third-party logs** (YouTube, Algolia analytics) are outside the export scope.
+
+## Infrastructure Assumptions
+- Netlify serverless runtime for API routes.
+- Firebase Authentication for account identity.
+- Firestore for primary application data.
+- Algolia for search indexing.
+- YouTube API for metadata lookup (not stored in export unless persisted in Firestore).
+
+## Privacy Policy Alignment
+- Privacy policy references self-service exports and lists included/excluded data.
+- Any future changes to export behavior must update:
+  1. `src/routes/privacy/+page.svelte`
+  2. `docs/SCHEMA_REFERENCE.md`
+  3. This document
+
+## Version History
+- 2026-01-30: Initial GDPR export documentation.

--- a/docs/SCHEMA_REFERENCE.md
+++ b/docs/SCHEMA_REFERENCE.md
@@ -55,17 +55,21 @@ The main collection for reaction videos.
 
 User-specific data and preferences.
 
+**Document ID:** Firebase Auth UID (`userId`)
+
 #### Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `userId` | string | Yes | Firebase Auth user ID |
-| `displayName` | string | No | User's display name |
-| `email` | string | No | User's email |
 | `bookmarks` | array[string] | No | Array of reaction IDs bookmarked by user |
-| `following` | array[string] | No | Array of reactor user IDs the user follows |
-| `createdAt` | Timestamp | Yes | Account creation timestamp |
-| `updatedAt` | Timestamp | Yes | Last update timestamp |
+| `follows` | array[string] | No | Array of reactor user IDs the user follows |
+| `displayName` | string | No | Optional display name (if stored in Firestore) |
+| `email` | string | No | Optional email (if stored in Firestore) |
+| `lastExportAt` | Timestamp | No | Last self-service export timestamp |
+| `createdAt` | Timestamp | No | Optional creation timestamp |
+| `updatedAt` | Timestamp | No | Optional last update timestamp |
+
+**Note**: Core account profile data (email, display name) primarily lives in Firebase Authentication.
 
 ---
 
@@ -77,15 +81,17 @@ User-created playlists of reactions.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `title` | string | Yes | Playlist title |
-| `description` | string | No | Playlist description |
+| `reactionBinomeIds` | array[string] | Yes | Array of reaction document IDs in playlist |
+| `originalVideoIds` | array[string] | Yes | Array of original YouTube IDs aligned with `reactionBinomeIds` |
 | `userId` | string | Yes | Creator's user ID |
-| `reactions` | array[string] | Yes | Array of reaction IDs in playlist |
+| `title` | string | No | Optional playlist title (legacy) |
+| `description` | string | No | Optional playlist description (legacy) |
 | `slug` | string | No | URL-friendly identifier |
 | `createdAt` | Timestamp | Yes | Creation timestamp |
-| `updatedAt` | Timestamp | Yes | Last update timestamp |
+| `updatedAt` | Timestamp | No | Last update timestamp |
 
 **Note**: Playlists do NOT have an `isPublished` field.
+**Legacy**: Older playlists may store `reactions` instead of `reactionBinomeIds`.
 
 ---
 
@@ -97,11 +103,17 @@ Temporary playback queues for sequential viewing.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `reactions` | array[string] | Yes | Array of reaction IDs in queue |
-| `currentIndex` | number | No | Index of currently playing reaction |
-| `autoplay` | boolean | No | Auto-advance to next reaction |
+| `slug` | string | Yes | Queue identifier (also used as document ID) |
+| `title` | string | Yes | Queue title |
+| `description` | string | No | Queue description |
+| `items` | array[object] | Yes | Ordered queue items ({ type: 'reaction' | 'playlist', id: string }) |
+| `ownerId` | string | Yes | Owner's user ID |
+| `ownerName` | string | No | Owner display name |
 | `createdAt` | Timestamp | Yes | Creation timestamp |
-| `expiresAt` | Timestamp | No | Optional expiration timestamp |
+| `updatedAt` | Timestamp | Yes | Last update timestamp |
+| `expiresAt` | Timestamp | No | Optional expiration timestamp (if used) |
+
+**Legacy**: Older queues may store `reactions`, `currentIndex`, or `autoplay`.
 
 ---
 
@@ -366,6 +378,7 @@ const docRef = await addDoc(collection(db, 'reactions'), {
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.1 | 2026-01-30 | Updated user data, playlist, and queue fields; documented export timestamp |
 | 1.0 | 2026-01-22 | Initial schema documentation |
 
 ---

--- a/src/lib/helpers/dataExport.js
+++ b/src/lib/helpers/dataExport.js
@@ -1,0 +1,48 @@
+export const EXPORT_VERSION = '1.0';
+
+const isTimestamp = (value) =>
+	value && typeof value === 'object' && typeof value.toDate === 'function';
+
+const isGeoPoint = (value) =>
+	value && typeof value === 'object' && typeof value.latitude === 'number' && typeof value.longitude === 'number';
+
+export const serializeFirestoreValue = (value) => {
+	if (Array.isArray(value)) {
+		return value.map(serializeFirestoreValue);
+	}
+	if (isTimestamp(value)) {
+		return value.toDate().toISOString();
+	}
+	if (isGeoPoint(value)) {
+		return {
+			latitude: value.latitude,
+			longitude: value.longitude
+		};
+	}
+	if (value && typeof value === 'object') {
+		const serialized = {};
+		for (const [key, entry] of Object.entries(value)) {
+			serialized[key] = serializeFirestoreValue(entry);
+		}
+		return serialized;
+	}
+	return value;
+};
+
+export const serializeFirestoreDoc = (docSnapshot) => ({
+	id: docSnapshot.id,
+	data: serializeFirestoreValue(docSnapshot.data())
+});
+
+export const sortById = (a, b) => a.id.localeCompare(b.id);
+
+export const sortByObjectId = (a, b) => a.objectID.localeCompare(b.objectID);
+
+export const chunkArray = (items, size) => {
+	if (!Array.isArray(items) || size <= 0) return [];
+	const chunks = [];
+	for (let i = 0; i < items.length; i += size) {
+		chunks.push(items.slice(i, i + size));
+	}
+	return chunks;
+};

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { onMount } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import { goto } from '$app/navigation';
     import {
       EmailAuthProvider,
@@ -21,6 +21,13 @@
     let deleteStep = 'confirm';
     let deletePassword = '';
     let deleteError = '';
+    let exportStatus = 'idle';
+    let exportError = '';
+    let exportPayload = null;
+    let exportFileName = '';
+    let exportGeneratedAt = '';
+    let exportRetryAt = '';
+    let exportBlobUrl = '';
 
     const providerLabels = {
       password: 'Email and password',
@@ -89,6 +96,58 @@
       }
 
       return error?.message || 'Failed to reauthenticate. Please try again.';
+    };
+
+    const requestExport = async () => {
+      exportError = '';
+      exportRetryAt = '';
+      exportStatus = 'loading';
+      exportPayload = null;
+
+      if (exportBlobUrl) {
+        URL.revokeObjectURL(exportBlobUrl);
+        exportBlobUrl = '';
+      }
+
+      try {
+        if (!auth.currentUser) {
+          showToast('You must be logged in to export your data.', TOASTS.ERROR);
+          exportStatus = 'error';
+          return;
+        }
+
+        const idToken = await auth.currentUser.getIdToken(true);
+        const response = await fetch('/api/account/export', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${idToken}`
+          }
+        });
+
+        const result = await response.json();
+
+        if (!response.ok) {
+          exportError = result.error || 'Failed to generate export.';
+          exportRetryAt = result.nextAllowedAt || '';
+          exportStatus = 'error';
+          return;
+        }
+
+        exportPayload = result.export;
+        exportFileName = result.fileName || 'pure-reactions-export.json';
+        exportGeneratedAt = result.generatedAt || exportPayload?.meta?.generatedAt || '';
+
+        const jsonText = JSON.stringify(exportPayload, null, 2);
+        exportBlobUrl = URL.createObjectURL(
+          new Blob([jsonText], { type: 'application/json' })
+        );
+        exportStatus = 'ready';
+        showToast('Your data export is ready to download.', TOASTS.SUCCESS);
+      } catch (error) {
+        console.error('Error generating export:', error);
+        exportError = 'An unexpected error occurred. Please try again.';
+        exportStatus = 'error';
+      }
     };
 
     const deleteAccount = async () => {
@@ -164,6 +223,12 @@
         handlePrivateRoute();
       }
     });
+
+    onDestroy(() => {
+      if (exportBlobUrl) {
+        URL.revokeObjectURL(exportBlobUrl);
+      }
+    });
   
   </script>
   
@@ -220,6 +285,76 @@
           >
             <span>Logout</span>
           </Button>
+        </div>
+      </section>
+
+      <section class="py-6">
+        <p class="text-xs font-semibold tracking-[0.2em] uppercase text-text-muted mb-4">
+          Privacy
+        </p>
+        <div class="border border-gray-600/50 rounded-lg p-5 bg-surface-dark">
+          <h2 class="text-lg font-semibold text-text mb-2">Download your data</h2>
+          <p class="text-sm text-text-muted mb-4">
+            Request a machine-readable export of the personal data tied to your account. The export is a JSON file you
+            can download and keep for your records.
+          </p>
+          <p class="text-xs text-text-muted mb-4">Exports are limited to one request every 24 hours.</p>
+          <div class="space-y-3 text-sm text-text-muted">
+            <div>
+              <p class="font-medium text-text">Included</p>
+              <ul class="list-disc list-inside space-y-1">
+                <li>Account profile details (email, display name, providers)</li>
+                <li>Your reactions and playback timelines</li>
+                <li>Playlists, queues, and bookmarks/follows</li>
+                <li>YouTube channel claim data (if submitted)</li>
+                <li>Search index entries for your published reactions</li>
+              </ul>
+            </div>
+            <div>
+              <p class="font-medium text-text">Not included</p>
+              <ul class="list-disc list-inside space-y-1">
+                <li>Infrastructure or transient logs (server logs, analytics)</li>
+                <li>Real-time co-watch session state</li>
+                <li>Deleted data that no longer exists in our systems</li>
+              </ul>
+            </div>
+          </div>
+          <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button
+              color="alternative"
+              on:click={requestExport}
+              disabled={exportStatus === 'loading'}
+              class="h-12 rounded-lg border border-gray-500 bg-surface text-text font-semibold text-sm tracking-wide hover:bg-surface-dark hover:border-gray-300"
+            >
+              {#if exportStatus === 'loading'}
+                Preparing export...
+              {:else}
+                Request data export
+              {/if}
+            </Button>
+            {#if exportStatus === 'ready' && exportBlobUrl}
+              <a
+                class="inline-flex items-center justify-center h-12 rounded-lg bg-accent-primary text-text-primary font-semibold text-sm tracking-wide hover:bg-accent-primary/90"
+                href={exportBlobUrl}
+                download={exportFileName}
+              >
+                Download export
+              </a>
+            {/if}
+          </div>
+          {#if exportGeneratedAt}
+            <p class="mt-3 text-xs text-text-muted" aria-live="polite">
+              Export generated at {new Date(exportGeneratedAt).toLocaleString()}.
+            </p>
+          {/if}
+          {#if exportRetryAt}
+            <p class="mt-2 text-xs text-text-muted" aria-live="polite">
+              Next export available after {new Date(exportRetryAt).toLocaleString()}.
+            </p>
+          {/if}
+          {#if exportError}
+            <p class="mt-3 text-sm text-red-400" aria-live="polite">{exportError}</p>
+          {/if}
         </div>
       </section>
 

--- a/src/routes/api/account/export/+server.js
+++ b/src/routes/api/account/export/+server.js
@@ -1,0 +1,351 @@
+import { json } from '@sveltejs/kit';
+import {
+	EXPORT_VERSION,
+	chunkArray,
+	serializeFirestoreDoc,
+	sortById,
+	sortByObjectId
+} from '$lib/helpers/dataExport';
+import {
+	COLLECTION_REACTION_BINOMES,
+	COLLECTION_USER_DATA,
+	COLLECTION_PLAYLISTS,
+	COLLECTION_QUEUES,
+	COLLECTION_YOUTUBE_CHANNEL_CLAIMS,
+	COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS,
+	FIREBASE_CONFIG
+} from '$lib/constants/firebase';
+
+let adminAuth = null;
+let adminDb = null;
+let adminFieldValue = null;
+let adminInitialized = false;
+
+const EXPORT_RATE_LIMIT_SECONDS = 60 * 60 * 24;
+const ALGOLIA_BATCH_LIMIT = 1000;
+
+async function initializeFirebaseAdmin() {
+	if (adminInitialized) {
+		return { adminAuth, adminDb, adminFieldValue };
+	}
+
+	try {
+		const { getAuth } = await import('firebase-admin/auth');
+		const { getFirestore, FieldValue } = await import('firebase-admin/firestore');
+		const { initializeApp, getApps, cert } = await import('firebase-admin/app');
+
+		let adminApp;
+		if (!getApps().length) {
+			if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+				const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT);
+				adminApp = initializeApp({
+					credential: cert(serviceAccount),
+					projectId: FIREBASE_CONFIG.projectId
+				});
+			} else {
+				adminApp = initializeApp({
+					projectId: FIREBASE_CONFIG.projectId
+				});
+			}
+		} else {
+			adminApp = getApps()[0];
+		}
+
+		adminAuth = getAuth(adminApp);
+		adminDb = getFirestore(adminApp);
+		adminFieldValue = FieldValue;
+		adminInitialized = true;
+	} catch (error) {
+		console.error('Failed to initialize Firebase Admin:', error);
+	}
+
+	return { adminAuth, adminDb, adminFieldValue };
+}
+
+function buildAuthProfile(userRecord) {
+	if (!userRecord) return null;
+	return {
+		uid: userRecord.uid,
+		email: userRecord.email ?? null,
+		emailVerified: Boolean(userRecord.emailVerified),
+		displayName: userRecord.displayName ?? null,
+		photoURL: userRecord.photoURL ?? null,
+		phoneNumber: userRecord.phoneNumber ?? null,
+		disabled: Boolean(userRecord.disabled),
+		providerData: (userRecord.providerData || []).map((provider) => ({
+			providerId: provider.providerId,
+			uid: provider.uid,
+			displayName: provider.displayName ?? null,
+			email: provider.email ?? null,
+			phoneNumber: provider.phoneNumber ?? null,
+			photoURL: provider.photoURL ?? null
+		})),
+		customClaims: userRecord.customClaims || {},
+		metadata: {
+			creationTime: userRecord.metadata?.creationTime ?? null,
+			lastSignInTime: userRecord.metadata?.lastSignInTime ?? null,
+			lastRefreshTime: userRecord.metadata?.lastRefreshTime ?? null
+		}
+	};
+}
+
+function buildRateLimitPayload({ lastExportAtMs, nowMs }) {
+	const retryAfterSeconds = Math.ceil((EXPORT_RATE_LIMIT_SECONDS * 1000 - (nowMs - lastExportAtMs)) / 1000);
+	const nextAllowedAt = new Date(lastExportAtMs + EXPORT_RATE_LIMIT_SECONDS * 1000).toISOString();
+	return { retryAfterSeconds, nextAllowedAt };
+}
+
+async function fetchCollectionByField(adminDbInstance, collectionName, field, value) {
+	if (!collectionName) {
+		return [];
+	}
+	const snapshot = await adminDbInstance.collection(collectionName).where(field, '==', value).get();
+	return snapshot.docs.map(serializeFirestoreDoc).sort(sortById);
+}
+
+async function fetchUserDataDoc(adminDbInstance, userId) {
+	if (!COLLECTION_USER_DATA) {
+		return null;
+	}
+	const userDocRef = adminDbInstance.collection(COLLECTION_USER_DATA).doc(userId);
+	const userDocSnapshot = await userDocRef.get();
+	if (!userDocSnapshot.exists) {
+		return null;
+	}
+	return serializeFirestoreDoc(userDocSnapshot);
+}
+
+async function fetchYoutubeChannelVerifications(adminDbInstance, claims) {
+	if (!COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS) {
+		return [];
+	}
+	const channelIds = new Set();
+	claims.forEach((claim) => {
+		const channelId = claim?.data?.youtubeChannelId;
+		if (channelId) {
+			channelIds.add(channelId);
+		}
+	});
+
+	const verificationDocs = [];
+	for (const channelId of channelIds) {
+		const snapshot = await adminDbInstance
+			.collection(COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS)
+			.doc(channelId)
+			.get();
+		if (snapshot.exists) {
+			verificationDocs.push(serializeFirestoreDoc(snapshot));
+		}
+	}
+
+	return verificationDocs.sort(sortById);
+}
+
+async function fetchAlgoliaRecords(reactionIds) {
+	const appId = process.env.PUBLIC_ALGOLIA_APP_ID;
+	const adminKey = process.env.ALGOLIA_ADMIN_KEY;
+	const indexName = process.env.PUBLIC_ALGOLIA_REACTIONS_INDEX;
+
+	if (!reactionIds.length) {
+		return { indexName, records: [], missingObjectIDs: [] };
+	}
+
+	if (!appId || !adminKey || !indexName) {
+		return {
+			indexName,
+			records: [],
+			missingObjectIDs: [...reactionIds],
+			error: 'Algolia configuration is missing.'
+		};
+	}
+
+	const { default: algoliasearch } = await import('algoliasearch');
+	const client = algoliasearch(appId, adminKey);
+	const index = client.initIndex(indexName);
+
+	const records = [];
+	const missingObjectIDs = [];
+	const chunks = chunkArray(reactionIds, ALGOLIA_BATCH_LIMIT);
+
+	for (const chunk of chunks) {
+		const response = await index.getObjects(chunk);
+		response.results.forEach((result, indexOffset) => {
+			if (result) {
+				records.push(result);
+			} else {
+				missingObjectIDs.push(chunk[indexOffset]);
+			}
+		});
+	}
+
+	return {
+		indexName,
+		records: records.sort(sortByObjectId),
+		missingObjectIDs: missingObjectIDs.sort()
+	};
+}
+
+export const POST = async ({ request }) => {
+	try {
+		const { adminAuth, adminDb, adminFieldValue } = await initializeFirebaseAdmin();
+
+		const authHeader = request.headers.get('Authorization');
+		if (!authHeader || !authHeader.startsWith('Bearer ')) {
+			return json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const idToken = authHeader.split('Bearer ')[1];
+
+		if (!adminAuth || !adminDb) {
+			console.error('Firebase Admin not initialized');
+			return json({ error: 'Server configuration error' }, { status: 500 });
+		}
+
+		let decodedToken;
+		try {
+			decodedToken = await adminAuth.verifyIdToken(idToken);
+		} catch (error) {
+			console.error('Token verification failed:', error);
+			return json({ error: 'Invalid token' }, { status: 401 });
+		}
+
+		const userId = decodedToken.uid;
+
+		const userDataDoc = await fetchUserDataDoc(adminDb, userId);
+		const lastExportAtMs = userDataDoc?.data?.lastExportAt
+			? new Date(userDataDoc.data.lastExportAt).getTime()
+			: null;
+		const nowMs = Date.now();
+
+		if (lastExportAtMs && nowMs - lastExportAtMs < EXPORT_RATE_LIMIT_SECONDS * 1000) {
+			const { retryAfterSeconds, nextAllowedAt } = buildRateLimitPayload({
+				lastExportAtMs,
+				nowMs
+			});
+			return json(
+				{
+					error: 'Export recently requested. Please wait before requesting another export.',
+					retryAfterSeconds,
+					nextAllowedAt
+				},
+				{
+					status: 429,
+					headers: {
+						'Retry-After': String(retryAfterSeconds)
+					}
+				}
+			);
+		}
+
+		let authProfile = null;
+		const metaNotes = [];
+		try {
+			const userRecord = await adminAuth.getUser(userId);
+			authProfile = buildAuthProfile(userRecord);
+		} catch (error) {
+			console.error('Failed to load auth profile:', error);
+			metaNotes.push('Auth profile unavailable for this export.');
+		}
+
+		const reactions = await fetchCollectionByField(adminDb, COLLECTION_REACTION_BINOMES, 'reactorId', userId);
+		const playlists = await fetchCollectionByField(adminDb, COLLECTION_PLAYLISTS, 'userId', userId);
+		const queues = await fetchCollectionByField(adminDb, COLLECTION_QUEUES, 'ownerId', userId);
+		const youtubeChannelClaims = await fetchCollectionByField(
+			adminDb,
+			COLLECTION_YOUTUBE_CHANNEL_CLAIMS,
+			'userId',
+			userId
+		);
+		const youtubeChannelVerifications = await fetchYoutubeChannelVerifications(adminDb, youtubeChannelClaims);
+
+		const reactionIds = reactions.map((reaction) => reaction.id);
+		const algoliaResult = await fetchAlgoliaRecords(reactionIds);
+		if (algoliaResult.error) {
+			metaNotes.push(algoliaResult.error);
+		}
+		const algoliaAvailable = Boolean(algoliaResult.indexName && !algoliaResult.error);
+
+		const generatedAt = new Date().toISOString();
+		const safeUserId = userId.slice(0, 8);
+		const dateStamp = generatedAt.slice(0, 10);
+		const fileName = `pure-reactions-export-${safeUserId}-${dateStamp}.json`;
+
+		const exportPayload = {
+			meta: {
+				exportVersion: EXPORT_VERSION,
+				generatedAt,
+				userId,
+				sources: {
+					auth: Boolean(authProfile),
+					firestore: true,
+					algolia: algoliaAvailable
+				},
+				counts: {
+					auth: authProfile ? 1 : 0,
+					firestore: {
+						userData: userDataDoc ? 1 : 0,
+						reactions: reactions.length,
+						playlists: playlists.length,
+						queues: queues.length,
+						youtubeChannelClaims: youtubeChannelClaims.length,
+						youtubeChannelVerifications: youtubeChannelVerifications.length
+					},
+					algolia: {
+						reactions: algoliaResult.records.length
+					}
+				},
+				excluded: [
+					'Infrastructure-level transient logs (Netlify, CDN, Firebase system logs).',
+					'Transient real-time shared session state (sharedSessions in Firebase Realtime Database).',
+					'Third-party service logs or analytics (YouTube, Algolia analytics).',
+					'Data that has been deleted or expired.'
+				],
+				notes: metaNotes
+			},
+			data: {
+				auth: authProfile,
+				firestore: {
+					userData: userDataDoc,
+					reactions,
+					playlists,
+					queues,
+					youtubeChannelClaims,
+					youtubeChannelVerifications
+				},
+				algolia: {
+					indexName: algoliaResult.indexName,
+					reactions: algoliaResult.records,
+					missingObjectIDs: algoliaResult.missingObjectIDs
+				}
+			}
+		};
+
+		if (COLLECTION_USER_DATA && adminFieldValue) {
+			try {
+				await adminDb
+					.collection(COLLECTION_USER_DATA)
+					.doc(userId)
+					.set({ lastExportAt: adminFieldValue.serverTimestamp() }, { merge: true });
+			} catch (error) {
+				console.error('Failed to update export timestamp:', error);
+			}
+		}
+
+		return json(
+			{
+				export: exportPayload,
+				fileName,
+				generatedAt
+			},
+			{
+				status: 200,
+				headers: {
+					'Cache-Control': 'no-store'
+				}
+			}
+		);
+	} catch (error) {
+		console.error('Error generating export:', error);
+		return json({ error: 'Failed to generate export' }, { status: 500 });
+	}
+};

--- a/src/routes/api/account/export/+server.js
+++ b/src/routes/api/account/export/+server.js
@@ -143,14 +143,14 @@ async function fetchYoutubeChannelVerifications(adminDbInstance, claims) {
 
 async function fetchAlgoliaRecords(reactionIds) {
 	const appId = process.env.PUBLIC_ALGOLIA_APP_ID;
-	const adminKey = process.env.ALGOLIA_ADMIN_KEY;
+	const searchKey = process.env.PUBLIC_ALGOLIA_SEARCH_API_KEY;
 	const indexName = process.env.PUBLIC_ALGOLIA_REACTIONS_INDEX;
 
 	if (!reactionIds.length) {
 		return { indexName, records: [], missingObjectIDs: [] };
 	}
 
-	if (!appId || !adminKey || !indexName) {
+	if (!appId || !searchKey || !indexName) {
 		return {
 			indexName,
 			records: [],
@@ -159,30 +159,39 @@ async function fetchAlgoliaRecords(reactionIds) {
 		};
 	}
 
-	const { default: algoliasearch } = await import('algoliasearch');
-	const client = algoliasearch(appId, adminKey);
-	const index = client.initIndex(indexName);
+	try {
+		const { default: algoliasearch } = await import('algoliasearch');
+		const client = algoliasearch(appId, searchKey);
+		const index = client.initIndex(indexName);
 
-	const records = [];
-	const missingObjectIDs = [];
-	const chunks = chunkArray(reactionIds, ALGOLIA_BATCH_LIMIT);
+		const records = [];
+		const missingObjectIDs = [];
+		const chunks = chunkArray(reactionIds, ALGOLIA_BATCH_LIMIT);
 
-	for (const chunk of chunks) {
-		const response = await index.getObjects(chunk);
-		response.results.forEach((result, indexOffset) => {
-			if (result) {
-				records.push(result);
-			} else {
-				missingObjectIDs.push(chunk[indexOffset]);
-			}
-		});
+		for (const chunk of chunks) {
+			const response = await index.getObjects(chunk);
+			response.results.forEach((result, indexOffset) => {
+				if (result) {
+					records.push(result);
+				} else {
+					missingObjectIDs.push(chunk[indexOffset]);
+				}
+			});
+		}
+
+		return {
+			indexName,
+			records: records.sort(sortByObjectId),
+			missingObjectIDs: missingObjectIDs.sort()
+		};
+	} catch (error) {
+		return {
+			indexName,
+			records: [],
+			missingObjectIDs: [...reactionIds],
+			error: `Algolia request failed: ${error?.message || 'Unknown error'}`
+		};
 	}
-
-	return {
-		indexName,
-		records: records.sort(sortByObjectId),
-		missingObjectIDs: missingObjectIDs.sort()
-	};
 }
 
 export const POST = async ({ request }) => {

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -14,7 +14,7 @@
     <h1 class="mb-6 text-4xl font-bold leading-tight text-text-primary md:text-5xl">
       Privacy Policy
     </h1>
-    <p class="text-sm text-text-muted">Effective Date: January 20, 2026</p>
+    <p class="text-sm text-text-muted">Effective Date: January 30, 2026</p>
   </header>
 
   <div class="prose-custom space-y-8 text-text-secondary">
@@ -30,15 +30,15 @@
           <h3 class="mb-2 text-lg font-medium text-text-primary">a. Account Information</h3>
           <p class="mb-2">When you create an account, we may collect:</p>
           <ul class="ml-6 list-disc space-y-1">
-            <li>Name, email address, and username</li>
-            <li>Profile information you provide</li>
+            <li>Name, email address, and sign-in provider identifiers</li>
+            <li>Profile information you provide (display name, photo)</li>
             <li>Account settings and preferences</li>
           </ul>
         </div>
 
         <div>
           <h3 class="mb-2 text-lg font-medium text-text-primary">b. User-Generated Content</h3>
-          <p>We process content you upload, link, or synchronize with the platform (e.g., reaction videos, commentary, translations).</p>
+          <p>We process content you upload, link, or synchronize with the platform (e.g., reaction videos, playlists, queues, bookmarks, follows, and channel claims).</p>
         </div>
 
         <div>
@@ -49,6 +49,7 @@
             <li>Device and browser information</li>
             <li>Analytics data for platform improvement</li>
           </ul>
+          <p class="mt-3">Some operational data (such as infrastructure logs) is transient and not stored as part of your account data export.</p>
         </div>
 
         <div>
@@ -59,6 +60,11 @@
             <li>Platform analytics</li>
             <li>Functional preferences</li>
           </ul>
+        </div>
+
+        <div>
+          <h3 class="mb-2 text-lg font-medium text-text-primary">e. Search Index</h3>
+          <p>We maintain a search index of published reactions (titles, tags, and channel handles) to power search.</p>
         </div>
       </div>
     </section>
@@ -97,7 +103,12 @@
         <li>Request export of your personal data in a machine-readable format</li>
       </ul>
       <p class="mt-4">
-        To exercise these rights, contact us at <a href="mailto:purereactions.app+privacy@gmail.com" class="text-accent-primary hover:text-accent-primary/80 transition-colors">purereactions.app+privacy@gmail.com</a>.
+        You can download a data export directly from Account Settings. The export includes account profile data, your reactions,
+        playlists/queues, bookmarks/follows, channel claims, and search index entries for published reactions. It does not include
+        transient infrastructure logs, real-time co-watch session state, or deleted data.
+      </p>
+      <p class="mt-4">
+        For other requests, contact us at <a href="mailto:purereactions.app+privacy@gmail.com" class="text-accent-primary hover:text-accent-primary/80 transition-colors">purereactions.app+privacy@gmail.com</a>.
       </p>
     </section>
 


### PR DESCRIPTION
Add a self-service GDPR data export flow and related documentation.

Changes:
- Add API endpoint (src/routes/api/account/export/+server.js) to generate JSON exports from Firebase/Algolia, with Firebase Admin initialization, Algolia batching, rate-limit (1 per 24h), export metadata and lastExportAt updates.
- Add serialization and helper utilities (src/lib/helpers/dataExport.js) for Firestore values, doc serialization, sorting and chunking.
- Integrate export UI in account settings (src/routes/account/+page.svelte): request/export flow, client-side token auth, blob creation/download, error/retry handling, and blob URL cleanup on destroy.
- Add GDPR documentation (docs/GDPR_DATA_EXPORT.md) and update privacy & schema docs (docs/SCHEMA_REFERENCE.md, src/routes/privacy/+page.svelte, docs/ACCOUNT_DELETION.md) to reflect export behavior and schema changes.
- Add AGENTS.md (site guidelines) for design/dev agents.

Notes:
- Export format/version = 1.0; arrays are deterministic (sorted); realtime shared session state and transient logs are excluded.
- Algolia integration requires env vars (PUBLIC_ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY, PUBLIC_ALGOLIA_REACTIONS_INDEX).

closes #112 