### PR TITLE
Add signup password checks and error passthrough

### DIFF
--- a/src/lib/helpers/firebase.js
+++ b/src/lib/helpers/firebase.js
@@ -795,6 +795,7 @@ export const getReactionsByIds = async (reactionIds) => {
 
 export const createUserWithEmailAndPasswordWrapper = async (email, password) => {
     let successful = false;
+    let errorDetails = null;
     try {
         const userCreds = await createUserWithEmailAndPassword(auth, email, password)
         const emailPrefix = typeof email === 'string' ? email.split('@')[0].trim() : '';
@@ -810,12 +811,17 @@ export const createUserWithEmailAndPasswordWrapper = async (email, password) => 
         });
         successful = true;
     } catch (error) {
-        const errorCode = error.code;
-        const errorMessage = error.message;
+        const errorCode = error?.code || 'auth/error';
+        const errorMessage = error?.message || '';
         showToast(errorCode);
         console.log('errorMessage', errorMessage);
+        errorDetails = {
+            code: error?.code,
+            message: errorMessage,
+            raw: error
+        };
     }
-    return successful;
+    return { successful, error: errorDetails };
 };
 
 export const signInWithEmailAndPasswordWrapper = async (email, password) => {

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -38,9 +38,10 @@ export async function load({ depends }) {
                 await invalidate('app:auth');
                 await goToRoute('/');
             }
+            return { successful };
         }
         if (action === 'signup' && email && password) {
-            const successful = await createUserWithEmailAndPasswordWrapper(email, password);
+            const { successful, error } = await createUserWithEmailAndPasswordWrapper(email, password);
             if (successful) {
                 showToast('Success! Check your email to confirm your account.', TOASTS.SUCCESS, 10000);
                 const user = await checkUserSignInStatusWrapper();
@@ -49,13 +50,16 @@ export async function load({ depends }) {
                 await invalidate('app:auth');
                 await goToRoute('/');
             }
+            return { successful, error };
         }
         if (action === 'logout') {
             await signOutWrapper();
             currentUser.set({});
             await invalidate('app:auth');
             await goToRoute('/');
+            return { successful: true };
         }
+        return { successful: false };
     };
     return {
         handleUserAction,

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -5,18 +5,124 @@
   let email = '';
   let password = '';
   let isSignUp = false;
+  let passwordRulesWithStatus = [];
+  let unmetPasswordRules = [];
+  let isPasswordValid = false;
+  let canSubmitSignUp = false;
+  let backendMissingRequirements = [];
+  let backendFallbackMessage = '';
+
+  const passwordRules = [
+    {
+      id: 'length',
+      label: 'Password must contain at least 6 characters',
+      test: (value) => value.length >= 6
+    },
+    {
+      id: 'upper',
+      label: 'Password must contain a upper case character',
+      test: (value) => /[A-Z]/.test(value)
+    },
+    {
+      id: 'numeric',
+      label: 'Password must contain a numeric character',
+      test: (value) => /[0-9]/.test(value)
+    },
+    {
+      id: 'lower',
+      label: 'Password must contain an lower case character',
+      test: (value) => /[a-z]/.test(value)
+    },
+    {
+      id: 'non-alphanumeric',
+      label: 'Password must contain a non-alphanumeric character',
+      test: (value) => /[^a-zA-Z0-9]/.test(value)
+    }
+  ];
+
+  const resetBackendPasswordFeedback = () => {
+    backendMissingRequirements = [];
+    backendFallbackMessage = '';
+  };
+
+  const parsePasswordRequirements = (message) => {
+    if (typeof message !== 'string') {
+      return null;
+    }
+    const match = message.match(/Missing password requirements:\s*\[(.*?)\]/i);
+    if (!match || !match[1]) {
+      return null;
+    }
+    return match[1]
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  };
+
+  const extractErrorMessage = (errorDetails) => {
+    if (!errorDetails) {
+      return null;
+    }
+    if (typeof errorDetails === 'string') {
+      return errorDetails;
+    }
+    if (typeof errorDetails?.message === 'string') {
+      return errorDetails.message;
+    }
+    if (typeof errorDetails?.raw?.message === 'string') {
+      return errorDetails.raw.message;
+    }
+    if (typeof errorDetails?.raw?.error?.message === 'string') {
+      return errorDetails.raw.error.message;
+    }
+    if (typeof errorDetails?.raw?.data?.error?.message === 'string') {
+      return errorDetails.raw.data.error.message;
+    }
+    return null;
+  };
 
   const handleLogin = () => {
+    resetBackendPasswordFeedback();
     data.handleUserAction('login', {email, password})
   };
 
-  const handleSignUp = () => {
-    data.handleUserAction('signup', {email, password})
+  const handleSignUp = async () => {
+    resetBackendPasswordFeedback();
+    if (!canSubmitSignUp) {
+      return;
+    }
+    const result = await data.handleUserAction('signup', {email, password});
+    if (!result?.error) {
+      return;
+    }
+    const message = extractErrorMessage(result.error);
+    if (!message || !message.includes('PASSWORD_DOES_NOT_MEET_REQUIREMENTS')) {
+      return;
+    }
+    const parsedRequirements = parsePasswordRequirements(message);
+    if (parsedRequirements && parsedRequirements.length) {
+      backendMissingRequirements = parsedRequirements;
+      return;
+    }
+    backendFallbackMessage = 'Password does not meet requirements. Please review the checklist and try again.';
+    console.error('Failed to parse password requirements', {
+      message,
+      error: result.error
+    });
   };
 
   const toggleForm = () => {
     isSignUp = !isSignUp;
+    resetBackendPasswordFeedback();
   };
+
+  $: passwordRulesWithStatus = passwordRules.map((rule) => ({
+    ...rule,
+    satisfied: rule.test(password || '')
+  }));
+  $: unmetPasswordRules = passwordRulesWithStatus.filter((rule) => !rule.satisfied);
+  $: isPasswordValid = unmetPasswordRules.length === 0;
+  $: canSubmitSignUp = Boolean(email) && isPasswordValid;
 </script>
 
 <div class="max-w-md mx-auto mt-10 p-6 bg-white rounded-lg shadow-md">
@@ -41,9 +147,53 @@
         <input type="email" placeholder="Email" class="w-full p-3 border border-gray-300 rounded" bind:value={email} />
       </div>
       <div class="mb-4">
-        <input type="password" placeholder="Password" class="w-full p-3 border border-gray-300 rounded" bind:value={password} />
+        <input
+          type="password"
+          placeholder="Password"
+          class="w-full p-3 border border-gray-300 rounded"
+          bind:value={password}
+          on:input={resetBackendPasswordFeedback}
+        />
+        <div class="mt-3">
+          <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Password requirements</p>
+          <ul class="mt-2 space-y-1 text-sm" aria-live="polite">
+            {#each passwordRulesWithStatus as rule}
+              <li class={`flex items-start gap-2 ${rule.satisfied ? 'text-emerald-700' : 'text-gray-600'}`}>
+                <span
+                  class={`mt-2 h-2 w-2 shrink-0 rounded-full ${rule.satisfied ? 'bg-emerald-600' : 'bg-gray-400'}`}
+                  aria-hidden="true"
+                ></span>
+                <span class={rule.satisfied ? 'line-through' : ''}>{rule.label}</span>
+              </li>
+            {/each}
+          </ul>
+          {#if backendMissingRequirements.length}
+            <div class="mt-3 rounded border border-amber-300 bg-amber-50 p-3 text-amber-800 text-sm" role="alert">
+              <p class="font-medium">Backend validation failed. Please also check:</p>
+              <ul class="mt-2 space-y-1">
+                {#each backendMissingRequirements as requirement}
+                  <li class="flex items-start gap-2">
+                    <span class="mt-2 h-2 w-2 shrink-0 rounded-full bg-amber-500" aria-hidden="true"></span>
+                    <span>{requirement}</span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {:else if backendFallbackMessage}
+            <div class="mt-3 rounded border border-amber-300 bg-amber-50 p-3 text-amber-800 text-sm" role="alert">
+              {backendFallbackMessage}
+            </div>
+          {/if}
+        </div>
       </div>
-      <button type="button" class="w-full bg-pink-700 text-white p-3 rounded" on:click={handleSignUp}>Sign Up</button>
+      <button
+        type="button"
+        class="w-full bg-pink-700 text-white p-3 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        on:click={handleSignUp}
+        disabled={!canSubmitSignUp}
+      >
+        Sign Up
+      </button>
     </form>
   <p class="mt-4 text-center">Already have an account? <button type="button" class="text-blue-500 underline-offset-2 hover:underline bg-transparent p-0 border-0" on:click={toggleForm}>Login</button></p>
   {/if}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -35,7 +35,7 @@
     },
     {
       id: 'non-alphanumeric',
-      label: 'Password must contain a non-alphanumeric character',
+      label: 'Password must contain a symbol',
       test: (value) => /[^a-zA-Z0-9]/.test(value)
     }
   ];
@@ -43,6 +43,13 @@
   const resetBackendPasswordFeedback = () => {
     backendMissingRequirements = [];
     backendFallbackMessage = '';
+  };
+
+  const mapRequirementLabel = (requirement) => {
+    const mapping = {
+      'Password must contain a non-alphanumeric character': 'Password must contain a symbol'
+    };
+    return mapping[requirement] || requirement;
   };
 
   const parsePasswordRequirements = (message) => {
@@ -56,7 +63,8 @@
     return match[1]
       .split(',')
       .map((item) => item.trim())
-      .filter(Boolean);
+      .filter(Boolean)
+      .map(mapRequirementLabel);
   };
 
   const extractErrorMessage = (errorDetails) => {


### PR DESCRIPTION
Return detailed error info from createUserWithEmailAndPasswordWrapper and propagate it to the layout handler so signup callers can react to backend validation. Update +layout handler to destructure and return {successful, error} for signup (and explicit returns for logout/default). Enhance the login page with client-side password requirement checks, real-time UI for rule satisfaction, disabled signup until requirements met, and parsing/display of backend "missing password requirements" messages with a fallback alert. These changes improve UX by preventing invalid submissions and surfacing actionable backend validation feedback.

closes #141 