### PR TITLE
Add playlist-transition tests and fix reuse logic

### DIFF
--- a/scripts/seed-twin-player-fixtures.mjs
+++ b/scripts/seed-twin-player-fixtures.mjs
@@ -15,7 +15,8 @@ const FIXTURES = [
   'tests/fixtures/reactions/twin-volume-stability.json',
   'tests/fixtures/reactions/twin-resume-after-config-pause.json',
   'tests/fixtures/reactions/twin-overlay-visibility.json',
-  'tests/fixtures/reactions/reaction-layout.json'
+  'tests/fixtures/reactions/reaction-layout.json',
+  'tests/fixtures/reactions/playlist-transitions.json'
 ];
 
 const VERIFICATION_FIXTURES = [

--- a/src/lib/composables/useTwinPlayers.ts
+++ b/src/lib/composables/useTwinPlayers.ts
@@ -527,7 +527,7 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       }
 
       if (typeof window !== 'undefined') {
-        window.__players = {
+        (window as any).__players = {
           original: nextValue.playerOriginal,
           reaction: nextValue.playerReaction
         };
@@ -2244,6 +2244,8 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       const originalVideoId = reactionData['originalVideoId'];
       const youtubePlaylistId = reactionData['youtubePlaylistId'];
 
+      const isSameReactionVideo = reactionVideoId === previousReactionVideoId;
+
       const rawOffsetStartTime = Number(reactionData['offsetStartTime'] ?? 0);
       const offsetStartTime = Number.isFinite(rawOffsetStartTime) && rawOffsetStartTime >= 0
         ? Math.round(rawOffsetStartTime * 10) / 10
@@ -2261,8 +2263,10 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       const canReuseReactionPlayer =
         Boolean(snapshotBefore.playerReaction) &&
         Boolean(reactionVideoId) &&
-        reactionVideoId === previousReactionVideoId &&
+        isSameReactionVideo &&
         Boolean(document.getElementById('player-reaction'));
+
+      const effectivePreviousReactionTime = isSameReactionVideo ? previousReactionTime : undefined;
 
       if (!canReuseReactionPlayer && snapshotBefore.playerReaction?.destroy) {
         snapshotBefore.playerReaction.destroy();
@@ -2353,7 +2357,7 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         fullscreenOverlayVisible: true,
         currentVolumeReactionVideo: 100,
         bothVideosStarted: preserveReactionTime ? snapshotBefore.bothVideosStarted : Boolean(options.autoPlay),
-        reactionCurrentTime: typeof previousReactionTime === 'number' ? previousReactionTime : offsetStartTime || 0,
+        reactionCurrentTime: typeof effectivePreviousReactionTime === 'number' ? effectivePreviousReactionTime : offsetStartTime || 0,
         reactionDuration:
           typeof nextPlayerReaction?.getDuration === 'function' ? Number(nextPlayerReaction.getDuration()) || 0 : snapshotBefore.reactionDuration,
         seekMin: offsetStartTime || 0,
@@ -2380,9 +2384,9 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         }
       }
 
-      if (typeof previousReactionTime === 'number' && typeof nextPlayerReaction?.seekTo === 'function' && !canReuseReactionPlayer) {
+      if (typeof effectivePreviousReactionTime === 'number' && typeof nextPlayerReaction?.seekTo === 'function' && !canReuseReactionPlayer) {
         try {
-          nextPlayerReaction.seekTo(previousReactionTime, true);
+          nextPlayerReaction.seekTo(effectivePreviousReactionTime, true);
         } catch {
           // ignore
         }
@@ -4057,6 +4061,12 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       registerOverlayRef
     }
   };
+
+  if (typeof window !== 'undefined') {
+    (window as any).__actions = result.actions;
+  }
+
+  return result;
 }
 
 function getInitialUrlState() {

--- a/src/lib/composables/useTwinPlayers.ts
+++ b/src/lib/composables/useTwinPlayers.ts
@@ -1086,6 +1086,18 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         handleStateChangeInReactionVideo(reactionPlayerState, newReactionState);
         reactionPlayerState = newReactionState;
       }
+      
+      // If the reaction video is UNSTARTED or CUED (e.g., after autoplay transition),
+      // pause the original video and wait for user interaction to start both videos
+      if (newReactionState === YT?.PlayerState?.UNSTARTED || newReactionState === YT?.PlayerState?.CUED) {
+        const originalState = getPlayerStateSafely(playerOriginal);
+        if (originalState === YT.PlayerState.PLAYING || originalState === YT.PlayerState.BUFFERING) {
+          pausePlayerWithTrace('original', playerOriginal, 'reaction UNSTARTED/CUED during sync loop');
+        }
+        scheduleNextSync(250, runSyncCycle);
+        return;
+      }
+      
       const previousReactionTime = snapshot.reactionCurrentTime;
       const reactionCurrentTime = parseFloat(playerReaction.getCurrentTime().toFixed(1));
       const rawDuration = typeof playerReaction.getDuration === 'function' ? Number(playerReaction.getDuration()) : Number.NaN;
@@ -2268,6 +2280,20 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
 
       const effectivePreviousReactionTime = isSameReactionVideo ? previousReactionTime : undefined;
 
+      // Compute initial volumes from the configurations at offsetStartTime
+      const initialOriginalVolume = getCurrentVolumeFromVolumeConfigs(
+        offsetStartTime || 0,
+        volumeConfigs,
+        globalGain,
+        timeOffset
+      );
+      const initialReactionVolume = getCurrentVolumeFromVolumeConfigs(
+        offsetStartTime || 0,
+        reactionVolumeConfigs,
+        1.0,
+        timeOffset
+      );
+
       if (!canReuseReactionPlayer && snapshotBefore.playerReaction?.destroy) {
         snapshotBefore.playerReaction.destroy();
       }
@@ -2296,7 +2322,18 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
 
       if (originalVideoId && typeof snapshotBefore.playerOriginal?.loadVideoById === 'function') {
         try {
-          snapshotBefore.playerOriginal.loadVideoById(originalVideoId);
+          // When switching to a different reaction video, cue (don't play) the original video
+          // so it waits for the reaction video to be started by the user
+          if (!isSameReactionVideo) {
+            if (typeof snapshotBefore.playerOriginal.cueVideoById === 'function') {
+              snapshotBefore.playerOriginal.cueVideoById(originalVideoId);
+              console.debug('[TwinPlayers] Cued original video (different reaction video)', { originalVideoId });
+            } else {
+              snapshotBefore.playerOriginal.loadVideoById(originalVideoId);
+            }
+          } else {
+            snapshotBefore.playerOriginal.loadVideoById(originalVideoId);
+          }
         } catch (error) {
           console.error('Failed to load original video by id', error);
         }
@@ -2353,10 +2390,10 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         playerOriginal: snapshotBefore.playerOriginal,
         playerReaction: nextPlayerReaction,
         currentStateOriginalVideo: -1,
-        currentVolumeOriginalVideo: 100,
+        currentVolumeOriginalVideo: initialOriginalVolume,
         fullscreenOverlayVisible: true,
-        currentVolumeReactionVideo: 100,
-        bothVideosStarted: preserveReactionTime ? snapshotBefore.bothVideosStarted : Boolean(options.autoPlay),
+        currentVolumeReactionVideo: initialReactionVolume,
+        bothVideosStarted: isSameReactionVideo && preserveReactionTime ? snapshotBefore.bothVideosStarted : Boolean(options.autoPlay),
         reactionCurrentTime: typeof effectivePreviousReactionTime === 'number' ? effectivePreviousReactionTime : offsetStartTime || 0,
         reactionDuration:
           typeof nextPlayerReaction?.getDuration === 'function' ? Number(nextPlayerReaction.getDuration()) || 0 : snapshotBefore.reactionDuration,
@@ -2373,8 +2410,48 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         })()
       });
 
+      console.debug('[TwinPlayers] state updated in updateReactionVideo', {
+        isSameReactionVideo,
+        preserveReactionTime,
+        bothVideosStarted: isSameReactionVideo && preserveReactionTime ? snapshotBefore.bothVideosStarted : Boolean(options.autoPlay),
+        initialOriginalVolume,
+        initialReactionVolume,
+        reactionVideoId,
+        previousReactionVideoId
+      });
+
       enforceReactionMuteMode();
       await setPlaylistData(get(state).playlistDocumentId, youtubePlaylistId);
+
+      // Explicitly apply the computed volumes to the players
+      if (typeof snapshotBefore.playerOriginal?.setVolume === 'function') {
+        try {
+          snapshotBefore.playerOriginal.setVolume(initialOriginalVolume);
+          console.debug('[TwinPlayers] Applied original volume after transition', { initialOriginalVolume });
+        } catch (error) {
+          console.error('[TwinPlayers] Failed to set original volume', error);
+        }
+      }
+      if (typeof nextPlayerReaction?.setVolume === 'function') {
+        try {
+          nextPlayerReaction.setVolume(initialReactionVolume);
+          console.debug('[TwinPlayers] Applied reaction volume after transition', { initialReactionVolume });
+        } catch (error) {
+          console.error('[TwinPlayers] Failed to set reaction volume', error);
+        }
+      }
+
+      // When switching to a different reaction video, explicitly stop the original video
+      // AFTER all volume and state operations to prevent it from auto-playing
+      if (!isSameReactionVideo && typeof snapshotBefore.playerOriginal?.stopVideo === 'function') {
+        try {
+          await tick(); // Let all previous operations complete
+          snapshotBefore.playerOriginal.stopVideo();
+          console.debug('[TwinPlayers] Stopped original video after volume application (different reaction)');
+        } catch (error) {
+          console.error('[TwinPlayers] Failed to stop original video', error);
+        }
+      }
 
       if (!preserveReactionTime && canReuseReactionPlayer && typeof nextPlayerReaction?.seekTo === 'function') {
         try {
@@ -2394,10 +2471,16 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
 
       try {
         await tick();
+        // When preserving time with the same reaction video and both videos were already started,
+        // resume playback immediately
         if (preserveReactionTime && get(state).bothVideosStarted) {
           handleStateChangeInReactionVideo(YT.PlayerState.BUFFERING, YT.PlayerState.PLAYING);
           pollVideoCurrentTime();
-        } else {
+        } else if (isSameReactionVideo || Boolean(options.autoPlay)) {
+          // Only sync/start videos if:
+          // 1. Same reaction video (reusing player), OR
+          // 2. AutoPlay is explicitly enabled
+          // Otherwise, wait for user to start the new reaction video
           syncVideos();
           if (get(state).bothVideosStarted) {
             pollVideoCurrentTime();

--- a/tests/fixtures/reactions/playlist-transitions.json
+++ b/tests/fixtures/reactions/playlist-transitions.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "description": "Twin-player fixture: Playlist Transition timing preservation",
+  "description": "Twin-player fixture: Playlist Transition timing preservation and volume state",
   "docs": [
     {
       "id": "playlist-trans-A",
@@ -11,7 +11,9 @@
         "originalVideoTitle": "Original Video A",
         "reactionVideoId": "8-3PahRtgF4",
         "reactionVideoTitle": "Reaction Video Same",
-        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }],
+        "volumeTimeline": [{ "t": 0, "volume": 0 }],
+        "reactionVolumeTimeline": [{ "t": 0, "volume": 100 }]
       }
     },
     {
@@ -23,7 +25,9 @@
         "originalVideoTitle": "Original Video B",
         "reactionVideoId": "8-3PahRtgF4",
         "reactionVideoTitle": "Reaction Video Same",
-        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }],
+        "volumeTimeline": [{ "t": 0, "volume": 0 }],
+        "reactionVolumeTimeline": [{ "t": 0, "volume": 100 }]
       }
     },
     {
@@ -35,7 +39,9 @@
         "originalVideoTitle": "Original Video C",
         "reactionVideoId": "qg6b4b0FAB4",
         "reactionVideoTitle": "Reaction Video Different",
-        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }],
+        "volumeTimeline": [{ "t": 0, "volume": 100 }],
+        "reactionVolumeTimeline": [{ "t": 0, "volume": 0 }]
       }
     }
   ]

--- a/tests/fixtures/reactions/playlist-transitions.json
+++ b/tests/fixtures/reactions/playlist-transitions.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "description": "Twin-player fixture: Playlist Transition timing preservation",
+  "docs": [
+    {
+      "id": "playlist-trans-A",
+      "data": {
+        "isPublished": true,
+        "offsetStartTime": 0,
+        "originalVideoId": "8-3PahRtgF4",
+        "originalVideoTitle": "Original Video A",
+        "reactionVideoId": "8-3PahRtgF4",
+        "reactionVideoTitle": "Reaction Video Same",
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+      }
+    },
+    {
+      "id": "playlist-trans-B",
+      "data": {
+        "isPublished": true,
+        "offsetStartTime": 0,
+        "originalVideoId": "qg6b4b0FAB4",
+        "originalVideoTitle": "Original Video B",
+        "reactionVideoId": "8-3PahRtgF4",
+        "reactionVideoTitle": "Reaction Video Same",
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+      }
+    },
+    {
+      "id": "playlist-trans-C",
+      "data": {
+        "isPublished": true,
+        "offsetStartTime": 10,
+        "originalVideoId": "qg6b4b0FAB4",
+        "originalVideoTitle": "Original Video C",
+        "reactionVideoId": "qg6b4b0FAB4",
+        "reactionVideoTitle": "Reaction Video Different",
+        "stateTimeline": [{ "state": 1, "t": 0, "targetTime": 0 }]
+      }
+    }
+  ]
+}

--- a/tests/twin-player-playlist-transitions.spec.js
+++ b/tests/twin-player-playlist-transitions.spec.js
@@ -66,4 +66,85 @@ test.describe('Playlist Transitions Timing', () => {
         expect(sAfterDiff.reactionCurrentTime).toBeLessThan(14); // 10 + some buffer
         expect(sAfterDiff.reactionCurrentTime).toBeGreaterThanOrEqual(9); // near 10
     });
+
+    test('should apply correct volume states when switching to different reaction video', async ({ page }) => {
+        // 1. Initial Load (Reaction A: original muted, reaction not muted)
+        await page.goto('/reaction/playlist-trans-A');
+        await waitForPlayersReady(page);
+        await startPlaybackInteraction(page);
+
+        // Wait for it to be playing
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.reactionPlayerState === 1; // Playing
+        }, { timeout: 30000 }).toBe(true);
+
+        const sInitial = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] Initial state A - Original volume: ${sInitial.currentVolumeOriginalVideo}, Reaction volume: ${sInitial.currentVolumeReactionVideo}`);
+        
+        // Playlist trans A has original muted (0) and reaction at 100
+        expect(sInitial.currentVolumeOriginalVideo).toBe(0);
+        expect(sInitial.currentVolumeReactionVideo).toBe(100);
+
+        // 2. Transition to DIFFERENT reaction video (Playlist Trans C: original NOT muted, reaction muted)
+        await page.evaluate(async () => {
+            await window.__actions.loadReactionInPlace('playlist-trans-C', { preserveReactionTime: true, autoPlay: true });
+        });
+
+        // Wait for transition to complete
+        await page.waitForTimeout(3000);
+
+        // Wait for players to be ready after transition
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.bothVideosStarted === true;
+        }, { timeout: 15000 }).toBe(true);
+
+        const sAfterTransition = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] After transition to C - Original volume: ${sAfterTransition.currentVolumeOriginalVideo}, Reaction volume: ${sAfterTransition.currentVolumeReactionVideo}`);
+
+        // Playlist trans C has original at 100 and reaction muted (0)
+        // These values should be derived from the new reaction's volume configurations
+        expect(sAfterTransition.currentVolumeOriginalVideo).toBe(100);
+        expect(sAfterTransition.currentVolumeReactionVideo).toBe(0);
+    });
+
+    test('should reset bothVideosStarted when switching to different reaction video', async ({ page }) => {
+        // 1. Initial Load (Reaction A)
+        await page.goto('/reaction/playlist-trans-A');
+        await waitForPlayersReady(page);
+        await startPlaybackInteraction(page);
+
+        // Wait for both videos to have started
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.bothVideosStarted === true;
+        }, { timeout: 30000 }).toBe(true);
+
+        const sInitial = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] Initial state A - bothVideosStarted: ${sInitial.bothVideosStarted}`);
+        expect(sInitial.bothVideosStarted).toBe(true);
+
+        // 2. Transition to DIFFERENT reaction video (Playlist Trans C)
+        await page.evaluate(async () => {
+            await window.__actions.loadReactionInPlace('playlist-trans-C', { preserveReactionTime: true, autoPlay: true });
+        });
+
+        // Wait briefly for the transition to begin
+        await page.waitForTimeout(1000);
+
+        // Check that bothVideosStarted is reset after transition
+        const sAfterTransition = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] After transition to C - bothVideosStarted: ${sAfterTransition.bothVideosStarted}, reactionPlayerState: ${sAfterTransition.reactionPlayerState}, originalPlayerState: ${sAfterTransition.originalPlayerState}`);
+
+        // With the fix, bothVideosStarted should be false initially after a transition to a different reaction video
+        // and then both videos should start playing together
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.bothVideosStarted === true && s?.reactionPlayerState === 1 && s?.originalPlayerState === 1;
+        }, { timeout: 15000 }).toBe(true);
+
+        const sFinal = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] Final state - Both videos playing: reaction=${sFinal.reactionPlayerState}, original=${sFinal.originalPlayerState}`);
+    });
 });

--- a/tests/twin-player-playlist-transitions.spec.js
+++ b/tests/twin-player-playlist-transitions.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import {
+    readTwinPlayersSnapshot,
+    waitForPlayersReady,
+    startPlaybackInteraction
+} from './utils/twin-player-helpers.js';
+
+test.describe('Playlist Transitions Timing', () => {
+
+    test.describe.configure({ timeout: 90000 });
+
+    test('should preserve timing for same reaction video and reset for different reaction video', async ({ page }) => {
+        // 1. Initial Load (Reaction A)
+        await page.goto('/reaction/playlist-trans-A');
+        await waitForPlayersReady(page);
+        await startPlaybackInteraction(page);
+
+        // Wait for it to be playing
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.reactionPlayerState === 1; // Playing
+        }, { timeout: 30000 }).toBe(true);
+
+        // 2. Seek to a recognizable time
+        const seekTime = 15;
+        await page.evaluate((time) => {
+            window.__players.reaction.seekTo(time, true);
+        }, seekTime);
+
+        // Wait for seek to settle
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.reactionCurrentTime;
+        }, { timeout: 10000 }).toBeGreaterThanOrEqual(seekTime);
+
+        // 3. Transition to same reaction video (Playlist Trans B)
+        // This transition happens between different reaction documents but points to the same underlying YouTube video.
+        await page.evaluate(async () => {
+             await window.__actions.loadReactionInPlace('playlist-trans-B', { preserveReactionTime: true, autoPlay: true });
+        });
+
+        // Wait for transition to complete (reaction doc ID changes in state)
+        // Note: isPublished is used as a proxy to check if transition happened or just check snapshot
+        await page.waitForTimeout(2000); 
+
+        const sAfterSame = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] Time after same-video transition: ${sAfterSame.reactionCurrentTime}`);
+        
+        // Timing should be preserved (at least close to where we were)
+        expect(sAfterSame.reactionCurrentTime).toBeGreaterThanOrEqual(seekTime);
+
+        // 4. Transition to DIFFERENT reaction video (Playlist Trans C)
+        await page.evaluate(async () => {
+             await window.__actions.loadReactionInPlace('playlist-trans-C', { preserveReactionTime: true, autoPlay: true });
+        });
+
+        // Wait for transition
+        await page.waitForTimeout(3000);
+
+        const sAfterDiff = await readTwinPlayersSnapshot(page);
+        console.log(`[Test] Time after diff-video transition: ${sAfterDiff.reactionCurrentTime}`);
+
+        // Timing should be RESET to offsetStartTime (which is 10 for playlist-trans-C)
+        // or 0 if it failed to reset. In the fixture I set offsetStartTime to 10.
+        // If it preserved time, it would be around 15-20.
+        expect(sAfterDiff.reactionCurrentTime).toBeLessThan(14); // 10 + some buffer
+        expect(sAfterDiff.reactionCurrentTime).toBeGreaterThanOrEqual(9); // near 10
+    });
+});


### PR DESCRIPTION
Add playlist-transitions fixture and spec, include it in the seeding script, and add emulator debug logs. Update useTwinPlayers to: cast window as any for __players, detect when the reaction video is the same across updates (isSameReactionVideo), only preserve/reuse previous reaction time when it is the same video (effectivePreviousReactionTime), and use that value for initial state and seeking. These changes ensure correct behavior during playlist transitions and avoid carrying over timing when the reaction video changes.

closes #144