### PR TITLE
Auto-hide, fullscreen and UI layout tweaks

### DIFF
--- a/src/lib/components/Navigation/SpeedDialNavigation.svelte
+++ b/src/lib/components/Navigation/SpeedDialNavigation.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount } from "svelte";
+  import { fly } from "svelte/transition";
   import {
     ShareNodesSolid,
     BookmarkSolid,
@@ -21,9 +22,29 @@
   import { reactionDial } from "$lib/stores/reactionDial";
 
   let isOpen = false;
+  let isVisible = true;
+  let hideTimeout;
   let dialRef;
   let triggerRef;
   const menuId = "speed-dial-menu";
+
+  const scheduleHide = () => {
+    if (typeof window === "undefined") return;
+    if (hideTimeout) clearTimeout(hideTimeout);
+    // Never hide if the menu is open
+    if (isOpen) return;
+
+    hideTimeout = setTimeout(() => {
+      isVisible = false;
+    }, 3000);
+  };
+
+  const handleScroll = () => {
+    if (!isVisible) {
+      isVisible = true;
+    }
+    scheduleHide();
+  };
 
   const copyCurrentUrl = () => {
     copyToClipboard($page.url.href);
@@ -56,10 +77,17 @@
     if (refocus) {
       triggerRef?.focus();
     }
+    scheduleHide();
   };
 
   const toggleDial = () => {
     isOpen = !isOpen;
+    if (isOpen) {
+      isVisible = true;
+      if (hideTimeout) clearTimeout(hideTimeout);
+    } else {
+      scheduleHide();
+    }
   };
 
   const handleWindowKeydown = (event) => {
@@ -79,9 +107,16 @@
     window.addEventListener("pointerdown", handlePointerDown, {
       passive: true,
     });
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    // Initial hide timer
+    scheduleHide();
+
     return () => {
       window.removeEventListener("keydown", handleWindowKeydown);
       window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("scroll", handleScroll);
+      if (hideTimeout) clearTimeout(hideTimeout);
     };
   });
 
@@ -180,63 +215,66 @@
   }
 </script>
 
-<div
-  bind:this={dialRef}
-  class="speed-dial fixed z-[95] flex flex-col items-start gap-2"
-  style="bottom: calc(var(--fab-offset-bottom) + var(--safe-area-inset-bottom)); left: calc(var(--fab-offset-left) + var(--safe-area-inset-left));"
-  data-open={isOpen}
->
-  <ul
-    id={menuId}
-    class={`dial-menu mb-2 flex flex-col items-start gap-2 transition duration-slow ease-cinematic ${isOpen ? "pointer-events-auto" : "pointer-events-none"}`}
-    aria-hidden={!isOpen}
+{#if isVisible}
+  <div
+    bind:this={dialRef}
+    transition:fly={{ y: 20, duration: 450, easing: (t) => t * (2 - t) }}
+    class="speed-dial fixed z-[95] flex flex-col items-start gap-2"
+    style="bottom: calc(var(--fab-offset-bottom) + var(--safe-area-inset-bottom)); left: calc(var(--fab-offset-left) + var(--safe-area-inset-left));"
+    data-open={isOpen}
   >
-    {#each options as option, index}
-      {#if option.type === "action"}
-        <li class="dial-item" style={`--item-delay: ${index * 50}ms`}>
-          <button
-            type="button"
-            class="dial-button"
-            tabindex={isOpen ? 0 : -1}
-            on:click={() => handleAction(option)}
-            aria-label={option.name}
-          >
-            <svelte:component this={option.icon} class="h-5 w-5" />
-            <span class="dial-label" aria-hidden="true">{option.name}</span>
-            <span class="sr-only">{option.name}</span>
-          </button>
-        </li>
-      {:else}
-        <li class="dial-item" style={`--item-delay: ${index * 50}ms`}>
-          <a
-            href={option.href}
-            class="dial-button"
-            tabindex={isOpen ? 0 : -1}
-            on:click={() => handleAction(option)}
-            aria-label={option.name}
-          >
-            <svelte:component this={option.icon} class="h-5 w-5" />
-            <span class="dial-label" aria-hidden="true">{option.name}</span>
-            <span class="sr-only">{option.name}</span>
-          </a>
-        </li>
-      {/if}
-    {/each}
-  </ul>
+    <ul
+      id={menuId}
+      class={`dial-menu mb-2 flex flex-col items-start gap-2 transition duration-slow ease-cinematic ${isOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+      aria-hidden={!isOpen}
+    >
+      {#each options as option, index}
+        {#if option.type === "action"}
+          <li class="dial-item" style={`--item-delay: ${index * 50}ms`}>
+            <button
+              type="button"
+              class="dial-button"
+              tabindex={isOpen ? 0 : -1}
+              on:click={() => handleAction(option)}
+              aria-label={option.name}
+            >
+              <svelte:component this={option.icon} class="h-5 w-5" />
+              <span class="dial-label" aria-hidden="true">{option.name}</span>
+              <span class="sr-only">{option.name}</span>
+            </button>
+          </li>
+        {:else}
+          <li class="dial-item" style={`--item-delay: ${index * 50}ms`}>
+            <a
+              href={option.href}
+              class="dial-button"
+              tabindex={isOpen ? 0 : -1}
+              on:click={() => handleAction(option)}
+              aria-label={option.name}
+            >
+              <svelte:component this={option.icon} class="h-5 w-5" />
+              <span class="dial-label" aria-hidden="true">{option.name}</span>
+              <span class="sr-only">{option.name}</span>
+            </a>
+          </li>
+        {/if}
+      {/each}
+    </ul>
 
-  <button
-    bind:this={triggerRef}
-    type="button"
-    class={`fab-button ${isOpen ? "rotate-45 bg-accent-primary text-background" : "bg-surface text-text-primary"}`}
-    aria-haspopup="true"
-    aria-expanded={isOpen}
-    aria-controls={menuId}
-    on:click={toggleDial}
-  >
-    <span class="sr-only">Toggle quick navigation</span>
-    <BarsSolid class="h-5 w-5" />
-  </button>
-</div>
+    <button
+      bind:this={triggerRef}
+      type="button"
+      class={`fab-button ${isOpen ? "rotate-45 bg-accent-primary text-background" : "bg-surface text-text-primary"}`}
+      aria-haspopup="true"
+      aria-expanded={isOpen}
+      aria-controls={menuId}
+      on:click={toggleDial}
+    >
+      <span class="sr-only">Toggle quick navigation</span>
+      <BarsSolid class="h-5 w-5" />
+    </button>
+  </div>
+{/if}
 
 <style>
   .sr-only {

--- a/src/lib/components/Video/VideoControl.svelte
+++ b/src/lib/components/Video/VideoControl.svelte
@@ -81,13 +81,21 @@
             if (!isKeyboardFocus && !isDragging && !isHoveringControls) {
                 isInteracting = false;
             }
-        }, 1800);
+        }, 3000);
     };
 
     const revealControls = () => {
         isInteracting = true;
         scheduleHide();
     };
+
+    let prevBothVideosStarted = bothVideosStarted;
+    $: if (bothVideosStarted && !prevBothVideosStarted) {
+        revealControls();
+        prevBothVideosStarted = bothVideosStarted;
+    } else if (!bothVideosStarted) {
+        prevBothVideosStarted = false;
+    }
 
     function handlePointerMove() {
         if (!bothVideosStarted) return;
@@ -423,7 +431,7 @@
                 </div>
 
                 {#if !isFullscreen}
-                    <div class="group relative hidden md:block">
+                    <div class="group relative">
                         <button
                             type="button"
                             class={iconButtonBase}
@@ -432,6 +440,20 @@
                         >
                             <ExpandSolid class="h-4 w-4" />
                             <span class="sr-only">Enter fullscreen</span>
+                        </button>
+                    </div>
+                {:else}
+                    <div class="group relative">
+                        <button
+                            type="button"
+                            class={iconButtonBase}
+                            on:click={() => dispatch('exitClick')}
+                            aria-label="Exit fullscreen"
+                        >
+                            <svg class="h-4 w-4 text-text-primary/80" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M5 9V5h4V3H3v6h2zm14-6h-6v2h4v4h2V3zm-6 18h6v-6h-2v4h-4v2zM5 15H3v6h6v-2H5v-4z" />
+                            </svg>
+                            <span class="sr-only">Exit fullscreen</span>
                         </button>
                     </div>
                 {/if}

--- a/src/lib/components/reaction/ControlDock.svelte
+++ b/src/lib/components/reaction/ControlDock.svelte
@@ -14,6 +14,7 @@
   export let onToggleAutoPlaylist = () => {};
   export let onToggleBars = () => {};
   export let onEnterFullscreen = () => {};
+  export let onExitClick = () => {};
 
   export let currentTime = 0;
   export let duration = 0;
@@ -44,6 +45,7 @@
       on:toggleAutoPlaylist={onToggleAutoPlaylist}
       on:toggleBars={onToggleBars}
       on:enterFullscreen={onEnterFullscreen}
+      on:exitClick={onExitClick}
       on:seek={(e) => onSeek(e.detail.time)}
     />
   </div>
@@ -60,7 +62,6 @@
       left: 0;
       right: 0;
       top: auto;
-      bottom: 0;
       margin-top: 0;
       padding-left: 12px;
       padding-right: 12px;

--- a/src/lib/components/reaction/MissingReactionPlaceholder.svelte
+++ b/src/lib/components/reaction/MissingReactionPlaceholder.svelte
@@ -31,7 +31,7 @@
   };
 </script>
 
-<div class="flex aspect-[16/9] flex-col items-center justify-center rounded-xl border border-dashed border-text-muted/40 bg-surface/40 p-6 text-center text-sm text-text-muted shadow-surface sm:aspect-[3/2]">
+<div class="flex w-full aspect-[16/9] flex-col items-center justify-center rounded-none md:rounded-xl border border-dashed border-text-muted/40 bg-surface/40 p-6 text-center text-sm text-text-muted shadow-surface">
   <div class="w-full max-w-sm space-y-4 text-left">
     <p class="text-center text-sm text-text-muted">
       Add a reaction video ID to preview the edited cut here.

--- a/src/lib/components/reaction/ReactionStage.svelte
+++ b/src/lib/components/reaction/ReactionStage.svelte
@@ -52,7 +52,7 @@
     function showControls() {
         if (!isMobileLandscape && !isFullscreen) return; // Only apply auto-hide in mobile landscape or fullscreen (if desired, currently targeting mobile landscape per request)
 
-        // Actually, request says: "The control dock should be visible as a bottom overlay when the user goes into landscape mode... disappears after 5 seconds"
+        // Actually, request says: "The control dock should be visible as a bottom overlay when the user goes into landscape mode... disappears after 3 seconds"
         // So we strictly enforce this logic when isMobileLandscape is true.
 
         controlsVisible = true;
@@ -61,7 +61,15 @@
             if (isMobileLandscape) {
                 controlsVisible = false;
             }
-        }, 5000);
+        }, 3000);
+    }
+
+    let prevBothVideosStarted = bothVideosStarted;
+    $: if (bothVideosStarted && !prevBothVideosStarted) {
+        showControls();
+        prevBothVideosStarted = bothVideosStarted;
+    } else if (!bothVideosStarted) {
+        prevBothVideosStarted = false;
     }
 
     function handleInteraction() {
@@ -87,6 +95,8 @@
         ? "opacity-0 pointer-events-none"
         : "opacity-100 pointer-events-auto";
 
+    let wrapperRef;
+
     const handleExitClick = () => dispatch("exitClick");
     const handleExitEnter = () => dispatch("exitEnter");
     const handleExitLeave = () => dispatch("exitLeave");
@@ -105,7 +115,32 @@
     const handleSyncVideos = () => dispatch("syncVideos");
     const handleToggleAutoPlaylist = () => dispatch("toggleAutoPlaylist");
     const handleToggleCinematicBars = () => dispatch("toggleCinematicBars");
-    const handleEnterFullscreen = () => dispatch("enterFullscreen");
+    const handleEnterFullscreen = async () => {
+        // Try to request browser fullscreen on the main wrapper if possible,
+        // then notify parent so app state can update.
+        try {
+            const el = typeof window !== "undefined" && wrapperRef ? wrapperRef : document.documentElement;
+            if (el && typeof el.requestFullscreen === "function") {
+                await el.requestFullscreen();
+            } else if (el && typeof el.webkitRequestFullscreen === "function") {
+                // Safari
+                el.webkitRequestFullscreen();
+            }
+        } catch (err) {
+            console.warn("Fullscreen request failed:", err);
+        }
+
+        dispatch("enterFullscreen");
+    };
+
+    function handleFullscreenChange() {
+        if (typeof document === "undefined") return;
+        const el = document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement;
+        if (!el) {
+            // Browser left fullscreen (e.g., via Escape). Notify parent to update app state.
+            dispatch("exitClick");
+        }
+    }
     const handleSeek = (time) => dispatch("seek", time);
 
     const OVERLAY_WIDTH_MIN = 5;
@@ -157,6 +192,12 @@
         if (isMobileLandscape) {
             showControls();
         }
+        if (typeof document !== "undefined") {
+            // Listen for browser-level fullscreen changes (Escape key, browser UI).
+            document.addEventListener("fullscreenchange", handleFullscreenChange);
+            document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
+            document.addEventListener("msfullscreenchange", handleFullscreenChange);
+        }
     });
 
     onDestroy(() => {
@@ -167,7 +208,31 @@
             );
         }
         if (controlsTimeout) clearTimeout(controlsTimeout);
+        
+        
+        if (typeof document !== "undefined") {
+            document.removeEventListener("fullscreenchange", handleFullscreenChange);
+            document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
+            document.removeEventListener("msfullscreenchange", handleFullscreenChange);
+        }
     });
+
+    // When the app's `isFullscreen` state is cleared, also exit browser fullscreen
+    // if the document is currently fullscreen. This keeps browser-level fullscreen
+    // in sync with the app state (e.g., when the user clicks the Exit button).
+    $: if (typeof document !== "undefined") {
+        if (!isFullscreen && document.fullscreenElement) {
+            // Best-effort exit; ignore errors.
+            document.exitFullscreen?.().catch(() => {});
+            if (typeof document.webkitExitFullscreen === "function") {
+                try {
+                    document.webkitExitFullscreen();
+                } catch (e) {
+                    /* ignore */
+                }
+            }
+        }
+    }
 
     $: console.log('Updated isMobileLandscape:', isMobileLandscape);
     $: console.log('Updated fullscreenOverlayVisible:', fullscreenOverlayVisible);
@@ -175,6 +240,7 @@
 </script>
 
 <div
+    bind:this={wrapperRef}
     class={`theater-wrapper ${
         isFullscreen
             ? "theater-wrapper--fullscreen fixed inset-0 z-50 m-0 h-screen w-screen overflow-hidden rounded-none bg-black px-0 py-0 text-text-primary shadow-none"
@@ -193,46 +259,8 @@
         handleInteraction(); // Any key shows controls? maybe just Enter/Space.
     }}
 >
-    <!-- Fullscreen overlay & exit button (only shown when fullscreen) -->
+    <!-- Fullscreen overlay (overlayRef still used for pointer events) -->
     {#if isFullscreen}
-        <div
-            class={`absolute left-6 top-6 z-50 transition-opacity duration-200 ease-cinematic ${isControlSurfaceVisible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"}`}
-        >
-            <button
-                type="button"
-                class={`group flex items-center overflow-hidden rounded-full bg-surface/40 ${isExitButtonExpanded ? "pl-3 pr-4" : "px-3"} py-2 text-sm font-semibold text-text-primary shadow-elevated backdrop-blur transition-all duration-200 ease-cinematic hover:-translate-y-0.5 hover:bg-surface/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent`}
-                on:click={handleExitClick}
-                on:mouseenter={handleExitEnter}
-                on:mouseleave={handleExitLeave}
-                on:focus={handleExitEnter}
-                on:blur={handleExitLeave}
-                on:touchstart={handleExitEnter}
-                on:touchend={handleExitLeave}
-                aria-label="Exit fullscreen"
-                title="Exit fullscreen"
-            >
-                <span
-                    class={`flex items-center justify-center overflow-hidden transition-all duration-200 ease-cinematic ${isExitButtonExpanded ? "w-0 opacity-0" : "w-4 opacity-80"}`}
-                >
-                    <svg
-                        class="h-4 w-4 text-text-primary/80"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                        aria-hidden="true"
-                    >
-                        <path
-                            d="M5 9V5h4V3H3v6h2zm14-6h-6v2h4v4h2V3zm-6 18h6v-6h-2v4h-4v2zM5 15H3v6h6v-2H5v-4z"
-                        />
-                    </svg>
-                </span>
-                <span
-                    class={`inline-flex items-center whitespace-nowrap transition-all duration-200 ease-cinematic ${isExitButtonExpanded ? "ml-2 max-w-xs opacity-100" : "ml-0 max-w-0 opacity-0"}`}
-                >
-                    Exit fullscreen
-                </span>
-            </button>
-        </div>
         <div
             class="absolute inset-0 z-40 cursor-default bg-transparent"
             bind:this={overlayRef}
@@ -247,7 +275,7 @@
         data-stage="container"
         class={isFullscreen
             ? "relative h-full w-full"
-            : "flex flex-col gap-0 md:grid md:gap-6 md:grid-cols-2 xl:gap-8"}
+            : "flex flex-col-reverse gap-0 md:grid md:gap-6 md:grid-cols-2 xl:gap-8"}
     >
         <!-- Original video player container -->
         <div
@@ -307,7 +335,7 @@
                     ? isReactionOverlay
                         ? `pointer-events-auto absolute ${overlayCornerClass} z-50 transition-opacity duration-300 ease-cinematic ${effectiveOverlayClass}`
                         : "absolute inset-0"
-                    : "relative overflow-hidden bg-black/80 shadow-surface w-[80vw] h-[45vw] mx-auto mt-4 rounded-lg md:w-auto md:h-auto md:mt-0 md:mx-0 md:rounded-xl md:aspect-[16/9]"}
+                    : "relative overflow-hidden bg-black/80 shadow-surface w-full h-[56.25vw] mx-auto mt-0 rounded-none md:w-auto md:h-auto md:mt-0 md:mx-0 md:rounded-xl md:aspect-[16/9]"}
                 style={isReactionOverlay ? "width: var(--overlay-width);" : ""}
             >
                 <div
@@ -357,6 +385,7 @@
             onToggleAutoPlaylist={handleToggleAutoPlaylist}
             onToggleBars={handleToggleCinematicBars}
             onEnterFullscreen={handleEnterFullscreen}
+            onExitClick={handleExitClick}
             currentTime={reactionCurrentTime}
             duration={reactionDuration}
             seekMin={offsetStartTime || 0}


### PR DESCRIPTION
Reduce control hide delays to 3s and add automatic visibility behavior: SpeedDial now auto-hides after inactivity/scroll with a fly transition and scheduleHide timer; video controls and reaction stage respect a 3s hide timeout and reveal when bothVideosStarted. Add fullscreen handling improvements: ReactionStage requests browser fullscreen when entering fullscreen, listens for browser fullscreenchange events to notify the app (exitClick) and attempts to sync/exit browser fullscreen when app state changes. Forward exitClick from ReactionStage -> ControlDock and wire through the VideoControl. Misc UI adjustments: make reaction placeholder full-width on small screens, tweak video container sizing and layout order (flex-col-reverse), remove a redundant bottom style in ControlDock, and clean up event listeners/timeouts.