### PR TITLE
Load Firebase config from PUBLIC_FIREBASE_CONFIG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,5 @@ PUBLIC_BASE_URL=https://yourdomain.com
 # Name it: pure-reactions-firebase-adminsdk-[something].json
 # It will be automatically ignored by git
 FIREBASE_SERVICE_ACCOUNT=./pure-reactions-firebase-adminsdk-[your-key-id].json
+
+PUBLIC_FIREBASE_CONFIG={"apiKey":"your_api_key","authDomain":"your_project_id.firebaseapp.com","projectId":"your_project_id","storageBucket":"your_project_id.appspot.com","messagingSenderId":"your_messaging_sender_id","appId":"your_app_id","measurementId":"your_measurement_id","databaseURL":"https://your_project_id-default-rtdb.your_region.firebasedatabase.app/"}

--- a/src/lib/constants/firebase.js
+++ b/src/lib/constants/firebase.js
@@ -13,16 +13,7 @@ const DEFAULT_YOUTUBE_CHANNEL_VERIFICATIONS = COLLECTION_YOUTUBE_CHANNEL_CLAIMS
     : undefined;
 export const COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS =
     env.PUBLIC_FIREBASE_COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS || DEFAULT_YOUTUBE_CHANNEL_VERIFICATIONS;
-export const FIREBASE_CONFIG = {
-    apiKey: "AIzaSyBqsnKIBnbRJqkpyOynZGLySf28AuqmOiE",
-    authDomain: "pure-reactions.firebaseapp.com",
-    projectId: "pure-reactions",
-    storageBucket: "pure-reactions.appspot.com",
-    messagingSenderId: "722795539356",
-    appId: "1:722795539356:web:0ec764c6b5834567603659",
-    measurementId: "G-T7TWND1C6C",
-    databaseURL: "https://pure-reactions-default-rtdb.europe-west1.firebasedatabase.app/"
-};
+export const FIREBASE_CONFIG = env.PUBLIC_FIREBASE_CONFIG ? JSON.parse(env.PUBLIC_FIREBASE_CONFIG) : {};
 
 // Initialize Firebase Realtime Database
 export const app = !getApps().length ? initializeApp(FIREBASE_CONFIG) : getApp();

--- a/src/lib/constants/firebase.js
+++ b/src/lib/constants/firebase.js
@@ -13,7 +13,15 @@ const DEFAULT_YOUTUBE_CHANNEL_VERIFICATIONS = COLLECTION_YOUTUBE_CHANNEL_CLAIMS
     : undefined;
 export const COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS =
     env.PUBLIC_FIREBASE_COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS || DEFAULT_YOUTUBE_CHANNEL_VERIFICATIONS;
-export const FIREBASE_CONFIG = env.PUBLIC_FIREBASE_CONFIG ? JSON.parse(env.PUBLIC_FIREBASE_CONFIG) : {};
+let parsedConfig = {};
+try {
+    parsedConfig = env.PUBLIC_FIREBASE_CONFIG ? JSON.parse(env.PUBLIC_FIREBASE_CONFIG) : {};
+} catch (e) {
+    console.error('[firebase] Failed to parse PUBLIC_FIREBASE_CONFIG. Raw value:', env.PUBLIC_FIREBASE_CONFIG);
+    console.error('[firebase] Parse error:', e);
+}
+
+export const FIREBASE_CONFIG = parsedConfig;
 
 // Initialize Firebase Realtime Database
 export const app = !getApps().length ? initializeApp(FIREBASE_CONFIG) : getApp();


### PR DESCRIPTION
Remove hardcoded FIREBASE_CONFIG and read configuration from the PUBLIC_FIREBASE_CONFIG environment variable instead. Adds an example PUBLIC_FIREBASE_CONFIG JSON entry to .env.example and updates src/lib/constants/firebase.js to parse env.PUBLIC_FIREBASE_CONFIG (falling back to an empty object) before initializing Firebase. This centralizes Firebase credentials in env config and avoids embedding credentials in source.