### PR TITLE
Add playlist gate tests and tune twin-player behavior

### DIFF
--- a/scripts/seed-twin-player-fixtures.mjs
+++ b/scripts/seed-twin-player-fixtures.mjs
@@ -8,6 +8,31 @@
 // the channel verification collection for Playwright tests.
 
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Minimal .env loader so env-based collection names are available.
+function loadDotEnvIfPresent(envPath = '.env') {
+  const abs = path.resolve(process.cwd(), envPath);
+  if (!fs.existsSync(abs)) return;
+  const raw = fs.readFileSync(abs, 'utf8');
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadDotEnvIfPresent();
 
 const FIXTURES = [
   'tests/fixtures/reactions/twin-basic-sync.json',
@@ -15,11 +40,16 @@ const FIXTURES = [
   'tests/fixtures/reactions/twin-play-trigger.json',
   'tests/fixtures/reactions/twin-volume-stability.json',
   'tests/fixtures/reactions/twin-resume-after-config-pause.json',
-  'tests/fixtures/reactions/reaction-layout.json'
+  'tests/fixtures/reactions/reaction-layout.json',
+  'tests/fixtures/reactions/twin-playlist-gate.json'
 ];
 
 const VERIFICATION_FIXTURES = [
   'tests/fixtures/verifications/reaction-layout.json'
+];
+
+const PLAYLIST_FIXTURES = [
+  'tests/fixtures/playlists/twin-playlist-gate.json'
 ];
 
 function stripFixtureArgs(argv) {
@@ -71,6 +101,35 @@ if (!process.exitCode && VERIFICATION_FIXTURES.length) {
         fixture,
         '--collection',
         verificationCollection,
+        ...passthrough
+      ],
+      {
+        stdio: 'inherit',
+        env: process.env
+      }
+    );
+
+    if (result.status !== 0) {
+      process.exitCode = result.status ?? 1;
+      break;
+    }
+  }
+}
+
+if (!process.exitCode && PLAYLIST_FIXTURES.length) {
+  const playlistCollection =
+    process.env.PUBLIC_FIREBASE_COLLECTION_PLAYLISTS ||
+    'playlists_local';
+
+  for (const fixture of PLAYLIST_FIXTURES) {
+    const result = spawnSync(
+      'node',
+      [
+        'scripts/seed-firestore-fixtures.mjs',
+        '--fixture',
+        fixture,
+        '--collection',
+        playlistCollection,
         ...passthrough
       ],
       {

--- a/src/lib/composables/useTwinPlayers.ts
+++ b/src/lib/composables/useTwinPlayers.ts
@@ -2647,6 +2647,15 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
       const nextOriginalVideoPlatform = normalizeOriginalVideoPlatform(reactionData?.originalVideoPlatform);
       const normalizedOriginalMetadata = normalizeOriginalVideoMetadata(reactionData);
 
+      const isPlaylistPage = typeof window !== 'undefined' && window.location?.pathname?.startsWith('/playlist/');
+      const platformChanged = snapshotBefore.originalVideoPlatform !== nextOriginalVideoPlatform;
+      if (isPlaylistPage && platformChanged) {
+        // Mixed original platforms (YouTube <-> TikTok) can leave stale player DOM/state.
+        // Force a full document reload for a clean player bootstrap.
+        window.location.assign(window.location.href);
+        return;
+      }
+
       const isSameReactionVideo = reactionVideoId === previousReactionVideoId;
 
       const rawOffsetStartTime = Number(reactionData['offsetStartTime'] ?? 0);
@@ -2968,15 +2977,10 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         } catch {
           // ignore
         }
-      } else if (!isSameReactionVideo && typeof nextPlayerReaction?.seekTo === 'function') {
-        // Different video: ensure we seek to its offsetStartTime even if reusing player (though unusual)
-        // or for the new player we just created.
-        try {
-          nextPlayerReaction.seekTo(offsetStartTime || 0, true);
-        } catch {
-          // ignore
-        }
       }
+      // Note: for new players with a different video, the `start` playerVar in playerVars
+      // already handles the initial seek position. An explicit seekTo here would cause the
+      // player to load video frames early (visible "cuing") before the user has clicked.
 
       try {
         await tick();
@@ -2994,11 +2998,12 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
         if (preserveReactionTime && get(state).bothVideosStarted) {
           handleStateChangeInReactionVideo(YT.PlayerState.BUFFERING, YT.PlayerState.PLAYING);
           pollVideoCurrentTime();
-        } else if (isSameReactionVideo || Boolean(options.autoPlay)) {
+        } else if ((isSameReactionVideo && snapshotBefore.bothVideosStarted) || Boolean(options.autoPlay)) {
           // Only sync/start videos if:
-          // 1. Same reaction video (reusing player), OR
-          // 2. AutoPlay is explicitly enabled
-          // Otherwise, wait for user to start the new reaction video
+          // 1. Same reaction video AND the user had already satisfied the gate before
+          //    this transition (i.e. they were actively watching). Do NOT auto-start if
+          //    the gate was still closed — the user must click to begin the new pair.
+          // 2. AutoPlay is explicitly enabled (e.g. queue/playlist auto-advance).
           syncVideos();
           if (get(state).bothVideosStarted) {
             pollVideoCurrentTime();
@@ -3071,6 +3076,12 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
     );
     if (isPlaylistPage) {
       const nextOriginalVideoId = nextSequenceItem?.originalVideoId || playlistDocument.originalVideoIds?.[nextIndex];
+      if (typeof nextOriginalVideoId === 'string' && typeof window !== 'undefined') {
+        const url = new URL(window.location.href);
+        url.searchParams.set('item', nextOriginalVideoId);
+        window.history.pushState(window.history.state, '', url.toString());
+      }
+
       loadReactionInPlace(nextReactionDocumentId, { preserveReactionTime: shouldPreserveReactionTime, autoPlay: true }).then(() => {
         const updatedIndex = nextIndex;
         const hasNext = updatedIndex < playlistItems.length - 1;
@@ -3078,13 +3089,6 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
           currentIndexInPlaylist: updatedIndex,
           hasNextIndexInPlaylist: hasNext
         });
-
-        if (typeof nextOriginalVideoId === 'string' && typeof window !== 'undefined') {
-          const url = new URL(window.location.href);
-          url.searchParams.set('item', nextOriginalVideoId);
-          window.history.pushState(window.history.state, '', url.toString());
-        }
-
       });
       return;
     }

--- a/src/routes/playlist/[slug]/+page.svelte
+++ b/src/routes/playlist/[slug]/+page.svelte
@@ -133,7 +133,6 @@
 
     await actions.loadReactionInPlace(reactionDocumentId, {
       preserveReactionTime: false,
-      autoPlay: true,
     });
   };
 

--- a/tests/fixtures/playlists/twin-playlist-gate.json
+++ b/tests/fixtures/playlists/twin-playlist-gate.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "description": "Playlist fixture: Click-gate carry-over test (two reactions, different originals)",
+  "docs": [
+    {
+      "id": "playlistGateTestPL001",
+      "data": {
+        "reactionBinomeIds": ["playlistGateReactionA001", "playlistGateReactionB002"],
+        "originalVideoIds": ["8-3PahRtgF4", "qg6b4b0FAB4"],
+        "sequenceItems": [
+          {
+            "id": "seq-gate-0",
+            "sourceType": "youtube-video",
+            "sourceIndex": 0,
+            "originalVideoId": "8-3PahRtgF4",
+            "originalVideoPlatform": "youtube",
+            "originalVideoUrl": "https://www.youtube.com/watch?v=8-3PahRtgF4",
+            "title": "Playlist Gate Test - Original A",
+            "channelTitle": "@testCreatorA"
+          },
+          {
+            "id": "seq-gate-1",
+            "sourceType": "youtube-video",
+            "sourceIndex": 1,
+            "originalVideoId": "qg6b4b0FAB4",
+            "originalVideoPlatform": "youtube",
+            "originalVideoUrl": "https://www.youtube.com/watch?v=qg6b4b0FAB4",
+            "title": "Playlist Gate Test - Original B",
+            "channelTitle": "@testCreatorB"
+          }
+        ],
+        "userId": "gateTestUserId001"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/reactions/twin-playlist-gate.json
+++ b/tests/fixtures/reactions/twin-playlist-gate.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "description": "Twin-player fixture: Playlist click-gate carry-over test (two reactions with different original videos)",
+  "docs": [
+    {
+      "id": "playlistGateReactionA001",
+      "data": {
+        "isPublished": true,
+        "offsetStartTime": 0,
+        "originalVideoAuthor": "@testCreatorA",
+        "originalVideoId": "8-3PahRtgF4",
+        "originalVideoTitle": "Playlist Gate Test - Original A",
+        "playbackTimeline": [
+          { "rate": 1, "t": 0 }
+        ],
+        "playlistId": "playlistGateTestPL001",
+        "reactionVideoAuthor": "@testReactor",
+        "reactionVideoId": "8-3PahRtgF4",
+        "reactionVideoTitle": "Playlist Gate Test - Reaction A",
+        "reactionVolumeTimeline": [],
+        "reactorId": "gateTestUserId001",
+        "stateTimeline": [
+          { "state": 1, "t": 0, "targetTime": 0 }
+        ],
+        "volumeTimeline": [],
+        "youtubePlaylistId": "",
+        "updatedAt": "2026-03-01T10:00:00Z"
+      }
+    },
+    {
+      "id": "playlistGateReactionB002",
+      "data": {
+        "isPublished": true,
+        "offsetStartTime": 0,
+        "originalVideoAuthor": "@testCreatorB",
+        "originalVideoId": "qg6b4b0FAB4",
+        "originalVideoTitle": "Playlist Gate Test - Original B",
+        "playbackTimeline": [
+          { "rate": 1, "t": 0 }
+        ],
+        "playlistId": "playlistGateTestPL001",
+        "reactionVideoAuthor": "@testReactor",
+        "reactionVideoId": "qg6b4b0FAB4",
+        "reactionVideoTitle": "Playlist Gate Test - Reaction B",
+        "reactionVolumeTimeline": [],
+        "reactorId": "gateTestUserId001",
+        "stateTimeline": [
+          { "state": 1, "t": 0, "targetTime": 0 }
+        ],
+        "volumeTimeline": [],
+        "youtubePlaylistId": "",
+        "updatedAt": "2026-03-01T10:00:00Z"
+      }
+    }
+  ]
+}

--- a/tests/playlist-click-gate.spec.js
+++ b/tests/playlist-click-gate.spec.js
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import {
+    installMockYouTubeApi,
+    readTwinPlayersSnapshot,
+    waitForPlayersReady,
+} from './utils/twin-player-helpers.js';
+
+const PLAYLIST_PAGE = '/playlist/playlistGateTestPL001';
+
+test.describe('Playlist Click-Gate Carry-Over', () => {
+
+    test.describe.configure({ timeout: 90000 });
+
+    test('Click gate must remain closed when navigating to another playlist item without clicking either video', async ({ page }) => {
+        await installMockYouTubeApi(page);
+
+        // Block the real YouTube IFrame API so it cannot overwrite our mock.
+        await page.route('**/www.youtube.com/iframe_api*', (route) => route.abort());
+        await page.route('**/www.youtube.com/s/player/**', (route) => route.abort());
+
+        // Capture console messages for diagnostics
+        const consoleLogs = [];
+        page.on('console', msg => consoleLogs.push(`[${msg.type()}] ${msg.text()}`));
+
+        // 1. Navigate to the playlist page (first item loads by default)
+        await page.goto(PLAYLIST_PAGE);
+
+        // 2. Wait for the playlist page to finish loading and display a reaction
+        //    The playlist page loads asynchronously: onMount calls loadSelectedReaction
+        //    which calls loadReactionInPlace, which creates the players.
+        try {
+            await page.waitForFunction(() => {
+                const players = window.__players;
+                return players?.original && players?.reaction;
+            }, null, { timeout: 45000 });
+        } catch (e) {
+            const diag = await page.evaluate(() => ({
+                players: !!window.__players,
+                original: !!window.__players?.original,
+                reaction: !!window.__players?.reaction,
+                bothVideosStarted: window.__players?.bothVideosStarted,
+                url: window.location.href,
+                bodyText: document.body?.innerText?.slice(0, 500),
+            })).catch(() => null);
+            throw new Error(
+                `Players never initialized on playlist page.\n` +
+                `Diagnostics: ${JSON.stringify(diag, null, 2)}\n` +
+                `Console logs:\n${consoleLogs.slice(-30).join('\n')}\n` +
+                `Original: ${e.message}`
+            );
+        }
+
+        await waitForPlayersReady(page, 30000);
+
+        // 3. Verify the click gate is closed on the first item
+        const snapshotBefore = await readTwinPlayersSnapshot(page);
+        expect(snapshotBefore, 'Twin players snapshot should exist on first item').toBeTruthy();
+        expect(snapshotBefore.bothVideosStarted, 'Click gate should be closed on first playlist item').toBe(false);
+
+        // 4. Verify the "click both videos" warning is visible
+        await expect(
+            page.getByText(/tap or click each video once to sync playback/i)
+        ).toBeVisible({ timeout: 10000 });
+
+        // 5. Navigate to the second playlist item WITHOUT clicking either video
+        const secondItem = page.getByRole('button').filter({ hasText: /Playlist Gate Test - Original B/i });
+        await expect(secondItem).toBeVisible({ timeout: 10000 });
+        await secondItem.click();
+
+        // 6. Wait for the transition to settle — players may be momentarily null
+        //    while loadReactionInPlace destroys old players and creates new ones.
+        try {
+            await page.waitForFunction(() => {
+                const players = window.__players;
+                return players?.original && players?.reaction;
+            }, null, { timeout: 45000 });
+        } catch (e) {
+            const diag = await page.evaluate(() => ({
+                hasPlayers: !!window.__players,
+                originalExists: !!window.__players?.original,
+                reactionExists: !!window.__players?.reaction,
+                bothVideosStarted: window.__players?.bothVideosStarted,
+                hasOriginalDiv: !!document.getElementById('player-original'),
+                hasReactionDiv: !!document.getElementById('player-reaction'),
+                url: window.location.href,
+                bodySnippet: document.body?.innerText?.slice(0, 400),
+            })).catch(() => null);
+            throw new Error(
+                `Players not ready after navigating to second item.\n` +
+                `Diagnostics: ${JSON.stringify(diag, null, 2)}\n` +
+                `Console logs:\n${consoleLogs.slice(-20).join('\n')}\n` +
+                `Original: ${e.message}`
+            );
+        }
+
+        await waitForPlayersReady(page, 30000);
+
+        // 7. The click gate MUST still be closed on the second item
+        await expect.poll(async () => {
+            const s = await readTwinPlayersSnapshot(page);
+            return s?.bothVideosStarted;
+        }, {
+            timeout: 15000,
+            message: 'Click gate should remain closed (bothVideosStarted=false) after navigating to a new playlist item without clicking either video'
+        }).toBe(false);
+
+        // 8. The warning must still be visible
+        await expect(
+            page.getByText(/tap or click each video once to sync playback/i)
+        ).toBeVisible({ timeout: 10000 });
+
+        // 9. Verify neither player is in a playing state
+        const snapshotAfter = await readTwinPlayersSnapshot(page);
+        expect(snapshotAfter, 'Twin players snapshot should exist on second item').toBeTruthy();
+        expect(snapshotAfter.bothVideosStarted, 'Click gate must be closed on second playlist item').toBe(false);
+    });
+});


### PR DESCRIPTION
Add Playwright test and fixtures for a playlist "click-gate" carry-over scenario, plus seed support for playlist fixtures. Update scripts/seed-twin-player-fixtures.mjs to load .env values and seed playlist fixtures into the configured playlists collection. Adjust useTwinPlayers to: force a full page reload on mixed original-platform transitions for playlist pages (avoid stale player DOM/state), remove an immediate seekTo to prevent visible cuing when loading new videos, refine auto-start logic so a reaction only auto-starts if the user had already started playback or autoPlay is explicitly enabled, and update history item URL earlier when advancing playlist items. Remove an unconditional autoPlay flag in the playlist page load to avoid starting playback without user intent.