### PR TITLE
Server-side loading for /reaction/[slug] + dynamic OG image (#208)

### DIFF
--- a/src/lib/server/firebaseAdmin.js
+++ b/src/lib/server/firebaseAdmin.js
@@ -1,13 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { FIREBASE_CONFIG } from '$lib/constants/firebase';
+import { env } from '$env/dynamic/private';
 
 let adminDb = null;
 let adminFieldValue = null;
 let adminInitialized = false;
 
 function resolveServiceAccount() {
-  const raw = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  const raw = env.FIREBASE_SERVICE_ACCOUNT || env.FIREBASE_SERVICE_ACCOUNT_JSON;
   if (raw?.trim()) {
     const trimmed = raw.trim();
     if (trimmed.startsWith('{')) {
@@ -20,7 +21,7 @@ function resolveServiceAccount() {
     }
   }
 
-  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  const credentialsPath = env.GOOGLE_APPLICATION_CREDENTIALS;
   if (credentialsPath?.trim()) {
     const absolutePath = path.resolve(process.cwd(), credentialsPath.trim());
     if (fs.existsSync(absolutePath)) {
@@ -65,4 +66,103 @@ export async function initializeFirebaseAdmin() {
   }
 
   return { adminDb, adminFieldValue };
+}
+
+/**
+ * Fetch a reaction document by its slug (document ID) using Firebase Admin.
+ * Returns a plain object with the fields needed for SSR/SEO, or null if not found.
+ */
+export async function getReactionBySlug(slug) {
+  const { COLLECTION_REACTION_BINOMES } = await import('$lib/constants/firebase');
+  const { adminDb } = await initializeFirebaseAdmin();
+  if (!adminDb) {
+    return null;
+  }
+
+  try {
+    const docRef = adminDb.collection(COLLECTION_REACTION_BINOMES).doc(slug);
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return null;
+    }
+    const data = docSnap.data();
+    // Return only the fields consumed by the SEO component in +page.svelte.
+    // Additional fields can be added here as noscript/SSR usage grows.
+    return {
+      id: docSnap.id,
+      reactionVideoId: data.reactionVideoId ?? null,
+      reactionVideoTitle: data.reactionVideoTitle ?? null,
+      reactionVideoAuthor: data.reactionVideoAuthor ?? null,
+      originalVideoTitle: data.originalVideoTitle ?? null,
+      originalVideoDescription: data.originalVideoDescription ?? null,
+      reactorDisplayName: data.reactorDisplayName ?? null,
+      thumbnailUrl: data.thumbnailUrl ?? null,
+      description: data.description ?? null,
+    };
+  } catch (error) {
+    console.error('Failed to fetch reaction by slug:', error);
+    return null;
+  }
+}
+
+/**
+ * Fetch a playlist document by its slug (document ID) using Firebase Admin.
+ * Returns a plain object with the fields needed for SSR/SEO, or null if not found.
+ */
+export async function getPlaylistBySlug(slug) {
+  const { COLLECTION_PLAYLISTS, COLLECTION_REACTION_BINOMES } = await import('$lib/constants/firebase');
+  const { adminDb } = await initializeFirebaseAdmin();
+  if (!adminDb) {
+    return null;
+  }
+
+  try {
+    const docRef = adminDb.collection(COLLECTION_PLAYLISTS).doc(slug);
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return null;
+    }
+    const data = docSnap.data();
+
+    const firstItemThumbnail = Array.isArray(data.sequenceItems)
+      ? (data.sequenceItems.find((i) => i.thumbnailUrl)?.thumbnailUrl ?? null)
+      : null;
+    const firstOriginalVideoId = Array.isArray(data.originalVideoIds)
+      ? (data.originalVideoIds[0] ?? null)
+      : null;
+
+    // Fetch the reaction video title from the first reaction document.
+    const firstReactionId = Array.isArray(data.reactionBinomeIds)
+      ? (data.reactionBinomeIds[0] ?? null)
+      : null;
+    let firstReactionVideoTitle = null;
+    let firstReactionDescription = null;
+    let firstReactionThumbnailUrl = null;
+    let firstReactionVideoId = null;
+    if (firstReactionId) {
+      const reactionSnap = await adminDb.collection(COLLECTION_REACTION_BINOMES).doc(firstReactionId).get();
+      if (reactionSnap.exists) {
+        const rd = reactionSnap.data();
+        firstReactionVideoTitle = rd.reactionVideoTitle ?? null;
+        firstReactionDescription = rd.description ?? null;
+        firstReactionThumbnailUrl = rd.thumbnailUrl ?? null;
+        firstReactionVideoId = rd.reactionVideoId ?? null;
+      }
+    }
+
+    return {
+      id: docSnap.id,
+      title: data.title ?? null,
+      description: data.description ?? null,
+      thumbnailUrl: firstItemThumbnail,
+      firstOriginalVideoId,
+      firstReactionVideoTitle,
+      firstReactionDescription,
+      firstReactionThumbnailUrl,
+      firstReactionVideoId,
+    };
+  } catch (error) {
+    console.error('Failed to fetch playlist by slug:', error);
+    return null;
+  }
 }

--- a/src/routes/playlist/[slug]/+page.js
+++ b/src/routes/playlist/[slug]/+page.js
@@ -1,9 +1,10 @@
 import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
-export function load({ params }) {
+export function load({ params, data }) {
   if (params.slug) {
     return {
+      ...data,
       slug: params.slug
     };
   }

--- a/src/routes/playlist/[slug]/+page.server.js
+++ b/src/routes/playlist/[slug]/+page.server.js
@@ -1,0 +1,12 @@
+import { getPlaylistBySlug } from '$lib/server/firebaseAdmin';
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ params }) {
+  const slug = params.slug;
+  if (!slug) {
+    return { playlist: null };
+  }
+
+  const playlist = await getPlaylistBySlug(slug);
+  return { playlist: playlist ?? null };
+}

--- a/src/routes/playlist/[slug]/+page.svelte
+++ b/src/routes/playlist/[slug]/+page.svelte
@@ -2,6 +2,7 @@
   import { page } from "$app/stores";
   import { browser } from "$app/environment";
   import { onDestroy, onMount } from "svelte";
+  import SEO from "$lib/components/SEO.svelte";
   import CreatorDetails from "$lib/components/Video/CreatorDetails.svelte";
   import PlaylistQueue from "$lib/components/Video/PlaylistQueue.svelte";
   import OtherReactions from "$lib/components/Video/OtherReactions.svelte";
@@ -18,6 +19,19 @@
   import { getPlaylist } from "$lib/helpers/firebase";
 
   export let data;
+
+  $: playlist = data?.playlist;
+  $: seoTitle = playlist?.title || playlist?.firstReactionVideoTitle || "Playlist";
+  $: seoDescription = playlist?.description || playlist?.firstReactionDescription || "Watch this playlist on Pure Reactions.";
+  $: seoImage =
+    playlist?.thumbnailUrl ||
+    playlist?.firstReactionThumbnailUrl ||
+    (playlist?.firstReactionVideoId
+      ? `https://i.ytimg.com/vi/${playlist.firstReactionVideoId}/hqdefault.jpg`
+      : null) ||
+    (playlist?.firstOriginalVideoId
+      ? `https://i.ytimg.com/vi/${playlist.firstOriginalVideoId}/hqdefault.jpg`
+      : undefined);
 
   // We start with an empty reaction slug and load the selected one client-side.
   const { state, actions } = useTwinPlayers({
@@ -201,6 +215,14 @@
     }
   };
 </script>
+
+<SEO
+  title={seoTitle}
+  description={seoDescription}
+  type="video.other"
+  image={seoImage}
+  canonical="/playlist/{data.slug}"
+/>
 
 <div class={$state.isLoading ? "" : "hidden"}>
   <div class="flex justify-center py-24">

--- a/src/routes/reaction/[slug]/+page.js
+++ b/src/routes/reaction/[slug]/+page.js
@@ -1,9 +1,10 @@
 import { error } from '@sveltejs/kit';
 /** @type {import('./$types').PageLoad} */
 
-export function load({ params }) {
+export function load({ params, data }) {
     if (params.slug) {
         return {
+            ...data,
             slug: params.slug
         };
     }

--- a/src/routes/reaction/[slug]/+page.server.js
+++ b/src/routes/reaction/[slug]/+page.server.js
@@ -1,0 +1,12 @@
+import { getReactionBySlug } from '$lib/server/firebaseAdmin';
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ params }) {
+  const slug = params.slug;
+  if (!slug) {
+    return { reaction: null };
+  }
+
+  const reaction = await getReactionBySlug(slug);
+  return { reaction: reaction ?? null };
+}

--- a/src/routes/reaction/[slug]/+page.svelte
+++ b/src/routes/reaction/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import { page } from "$app/stores";
+  import SEO from "$lib/components/SEO.svelte";
   import CreatorDetails from "$lib/components/Video/CreatorDetails.svelte";
   import PlaylistQueue from "$lib/components/Video/PlaylistQueue.svelte";
   import OtherReactions from "$lib/components/Video/OtherReactions.svelte";
@@ -19,6 +20,23 @@
   import { TOASTS } from "$lib/constants/toasts";
 
   export let data;
+
+  $: reaction = data?.reaction;
+  $: seoTitle = reaction?.reactionVideoTitle || reaction?.originalVideoTitle || "Reaction";
+  $: seoDescription = reaction
+    ? [
+        reaction.reactionVideoTitle && reaction.originalVideoTitle
+          ? `${reaction.reactorDisplayName || reaction.reactionVideoAuthor || "A reactor"} reacts to ${reaction.originalVideoTitle}`
+          : null,
+        reaction.description,
+        reaction.originalVideoDescription,
+      ].filter(Boolean).join(" — ") || "Watch this reaction on Pure Reactions."
+    : "Watch this reaction on Pure Reactions.";
+  $: seoImage =
+    reaction?.thumbnailUrl ||
+    (reaction?.reactionVideoId
+      ? `https://i.ytimg.com/vi/${reaction.reactionVideoId}/hqdefault.jpg`
+      : undefined);
 
   const { state, actions } = useTwinPlayers({ data });
 
@@ -168,6 +186,14 @@
     reactionDial.reset();
   });
 </script>
+
+<SEO
+  title={seoTitle}
+  description={seoDescription}
+  type="video.other"
+  image={seoImage}
+  canonical="/reaction/{data.slug}"
+/>
 
 <!-- Loading overlay - covers content while YouTube players initialize in the background -->
 {#if $state.isLoading}


### PR DESCRIPTION
* Initial plan

* Add server-side loading for /reaction/[slug] with dynamic OG image

- Add getReactionBySlug(slug) to src/lib/server/firebaseAdmin.js
- Create +page.server.js to fetch reaction data at SSR time
- Update +page.js to pass through server data
- Add SEO component with dynamic title, description, og:image (YouTube thumbnail), and og:type video.other

Agent-Logs-Url: https://github.com/animyrch/pure-reactions/sessions/0a1b1d0a-11fd-40cf-b84f-f037d33a5203



* Trim unused fields from getReactionBySlug return object per review

Agent-Logs-Url: https://github.com/animyrch/pure-reactions/sessions/0a1b1d0a-11fd-40cf-b84f-f037d33a5203



* Refactor Firebase service account resolution to use dynamic environment variables

* Add server-side playlist loader and SEO

Add getPlaylistBySlug in firebaseAdmin to fetch playlist and first-reaction metadata for SSR (title, description, thumbnails, first original/reaction video IDs). Introduce a +page.server.js to load playlist data on the server and return it as `data.playlist`. Update +page.js load signature to accept and forward server data. Update +page.svelte to derive SEO fields from the server-provided playlist and render an SEO component so playlist pages have proper metadata for SSR/SEO.

---------