### PR TITLE
Standardize FIREBASE_SERVICE_ACCOUNT env usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,6 @@ FIREBASE_SERVICE_ACCOUNT=./pure-reactions-firebase-adminsdk-[your-key-id].json
 
 # Option B – inline JSON string (CI / Netlify):
 # Set this as a private env var in your hosting dashboard.
-# FIREBASE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"...",...}
+# FIREBASE_SERVICE_ACCOUNT={"type":"service_account","project_id":"...",...}
 
 PUBLIC_FIREBASE_CONFIG={"apiKey":"your_api_key","authDomain":"your_project_id.firebaseapp.com","projectId":"your_project_id","storageBucket":"your_project_id.appspot.com","messagingSenderId":"your_messaging_sender_id","appId":"your_app_id","measurementId":"your_measurement_id","databaseURL":"https://your_project_id-default-rtdb.your_region.firebasedatabase.app/"}

--- a/docs/ACCOUNT_DELETION_SETUP.md
+++ b/docs/ACCOUNT_DELETION_SETUP.md
@@ -32,7 +32,7 @@ For local development, you have two options:
    export FIREBASE_SERVICE_ACCOUNT=./path-to-your-key.json
    ```
 
-#### Option 2: Using FIREBASE_SERVICE_ACCOUNT
+#### Option 2: Using inline JSON in FIREBASE_SERVICE_ACCOUNT
 
 Add to your `.env` file:
 ```

--- a/docs/ALGOLIA_OPERATIONS.md
+++ b/docs/ALGOLIA_OPERATIONS.md
@@ -84,7 +84,7 @@ Set these as **private** environment variables in the Netlify dashboard
 | Variable | Purpose |
 |---|---|
 | `ALGOLIA_ADMIN_KEY` | Algolia admin API key (write access) |
-| `FIREBASE_SERVICE_ACCOUNT_JSON` | Firebase service-account JSON (full inline string) |
+| `FIREBASE_SERVICE_ACCOUNT` | Firebase service-account credential, either a file path or full inline JSON |
 | `PUBLIC_ALGOLIA_APP_ID` | Algolia application ID |
 | `PUBLIC_ALGOLIA_REACTIONS_INDEX` | Algolia index name |
 
@@ -148,7 +148,7 @@ ALGOLIA_ADMIN_KEY=your_admin_key
 # Option A – file path (local dev):
 FIREBASE_SERVICE_ACCOUNT=./path/to/service-account.json
 # Option B – inline JSON (CI / Netlify):
-# FIREBASE_SERVICE_ACCOUNT_JSON=<full service-account JSON string>
+# FIREBASE_SERVICE_ACCOUNT=<full service-account JSON string>
 PUBLIC_FIREBASE_COLLECTION_REACTION_BINOMES=reactions
 ```
 

--- a/docs/TEST_FEATURES.md
+++ b/docs/TEST_FEATURES.md
@@ -21,7 +21,7 @@ The seeder writes to the collection from `.env` (`PUBLIC_FIREBASE_COLLECTION_REA
 This is intentionally hard to do by accident.
 
 - Set credentials via `FIREBASE_SERVICE_ACCOUNT=/abs/path/to/serviceAccount.json`
-  (or `FIREBASE_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'`).
+  or `FIREBASE_SERVICE_ACCOUNT='{"type":"service_account",...}'`.
 - Explicitly allow prod seeding: `ALLOW_PROD_SEED=1`
 - Run:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "build"
 
 # Reindex Algolia after every successful production deploy.
-# The plugin reads ALGOLIA_ADMIN_KEY and FIREBASE_SERVICE_ACCOUNT_JSON from
+# The plugin reads ALGOLIA_ADMIN_KEY and FIREBASE_SERVICE_ACCOUNT from
 # Netlify private env vars – no secrets are checked in or exposed to the client.
 [[plugins]]
   package = "./netlify/plugins/algolia-reindex"

--- a/netlify/plugins/algolia-reindex/index.js
+++ b/netlify/plugins/algolia-reindex/index.js
@@ -6,7 +6,7 @@
  *
  * Required Netlify env vars (private, server-side only):
  *   ALGOLIA_ADMIN_KEY
- *   FIREBASE_SERVICE_ACCOUNT_JSON   (full service-account JSON string)
+ *   FIREBASE_SERVICE_ACCOUNT        (file path or full service-account JSON string)
  *   PUBLIC_ALGOLIA_APP_ID
  *   PUBLIC_ALGOLIA_REACTIONS_INDEX
  */
@@ -17,7 +17,7 @@ const REQUIRED_ENV = [
   'PUBLIC_ALGOLIA_APP_ID',
   'ALGOLIA_ADMIN_KEY',
   'PUBLIC_ALGOLIA_REACTIONS_INDEX',
-  'FIREBASE_SERVICE_ACCOUNT_JSON'
+  'FIREBASE_SERVICE_ACCOUNT'
 ];
 
 export default {

--- a/scripts/algolia-index.mjs
+++ b/scripts/algolia-index.mjs
@@ -114,26 +114,20 @@ function ensureAdminApp({ projectId, target }) {
   }
 
   // target === 'prod'
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount) {
+    if (!serviceAccount.startsWith('{')) {
+      throw new Error(
+        'FIREBASE_SERVICE_ACCOUNT must be an inline JSON string in scripts/algolia-index.mjs; file paths are not supported.'
+      );
+    }
+
+    const parsed = JSON.parse(serviceAccount);
+
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
     });
-  }
-
-  // Fall back to file-path credential (local dev)
-  const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT;
-  if (serviceAccountPath) {
-    const abs = path.resolve(process.cwd(), serviceAccountPath);
-    if (fs.existsSync(abs)) {
-      const parsed = JSON.parse(fs.readFileSync(abs, 'utf8'));
-      return admin.initializeApp({
-        credential: admin.credential.cert(parsed),
-        projectId: projectId || parsed.project_id
-      });
-    }
   }
 
   return admin.initializeApp({ projectId });

--- a/scripts/approve-channel-claim.mjs
+++ b/scripts/approve-channel-claim.mjs
@@ -147,9 +147,9 @@ function ensureAdminApp({ projectId, target }) {
     return admin.initializeApp({ projectId });
   }
 
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount?.startsWith('{')) {
+    const parsed = JSON.parse(serviceAccount);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -192,8 +192,8 @@ async function approveClaim() {
       throw new Error('Refusing to approve on prod: set ALLOW_PROD_APPROVE=1 or pass --allowProd');
     }
 
-    if (!process.env.FIREBASE_SERVICE_ACCOUNT && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON');
+    if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT');
     }
   }
 

--- a/scripts/enrich-youtube.js
+++ b/scripts/enrich-youtube.js
@@ -42,7 +42,7 @@ function loadDotEnvIfPresent(envPath = '.env') {
 }
 
 function resolveServiceAccount() {
-  const raw = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  const raw = process.env.FIREBASE_SERVICE_ACCOUNT;
   if (!raw) {
     throw new Error('FIREBASE_SERVICE_ACCOUNT is required (JSON string or file path).');
   }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -36,7 +36,7 @@ function loadDotEnvIfPresent(envPath = '.env') {
 }
 
 function resolveServiceAccount() {
-  const raw = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  const raw = process.env.FIREBASE_SERVICE_ACCOUNT;
   if (!raw) {
     throw new Error('FIREBASE_SERVICE_ACCOUNT is required (JSON string or file path).');
   }

--- a/scripts/migrate-delete-legacy-timelines.mjs
+++ b/scripts/migrate-delete-legacy-timelines.mjs
@@ -125,9 +125,9 @@ function ensureAdminApp({ projectId, target }) {
     return admin.initializeApp({ projectId });
   }
 
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount?.startsWith('{')) {
+    const parsed = JSON.parse(serviceAccount);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -181,8 +181,8 @@ async function migrate() {
       throw new Error('Refusing to migrate prod: set ALLOW_PROD_MIGRATION=1 or pass --allowProd');
     }
 
-    if (!process.env.FIREBASE_SERVICE_ACCOUNT && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON');
+    if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT');
     }
 
     if (dryRun) {

--- a/scripts/migrate-prod-to-local.mjs
+++ b/scripts/migrate-prod-to-local.mjs
@@ -50,9 +50,9 @@ function loadDotEnvIfPresent(envPath = '.env') {
 function ensureAdminApp({ projectId }) {
   if (admin.apps.length) return admin.app();
 
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount?.startsWith('{')) {
+    const parsed = JSON.parse(serviceAccount);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -192,8 +192,8 @@ async function main() {
     configProjectId ||
     'pure-reactions';
 
-  if (!process.env.FIREBASE_SERVICE_ACCOUNT && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-    console.error('Missing credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON');
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+    console.error('Missing credentials: set FIREBASE_SERVICE_ACCOUNT');
     process.exit(1);
   }
 

--- a/scripts/reassign-reaction.mjs
+++ b/scripts/reassign-reaction.mjs
@@ -85,19 +85,12 @@ function ensureAdminApp({ projectId, target }) {
     return admin.initializeApp({ projectId });
   }
 
-  const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT;
-  if (serviceAccountPath) {
-    const abs = path.resolve(process.cwd(), serviceAccountPath);
-    const parsed = JSON.parse(fs.readFileSync(abs, 'utf8'));
-    return admin.initializeApp({
-      credential: admin.credential.cert(parsed),
-      projectId: projectId || parsed.project_id
-    });
-  }
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount) {
+    const parsed = serviceAccount.startsWith('{')
+      ? JSON.parse(serviceAccount)
+      : JSON.parse(fs.readFileSync(path.resolve(process.cwd(), serviceAccount), 'utf8'));
 
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -154,12 +147,9 @@ async function reassignReaction() {
         'Refusing to write to prod: pass --allowProd or set ALLOW_PROD_REASSIGN=1'
       );
     }
-    if (
-      !process.env.FIREBASE_SERVICE_ACCOUNT &&
-      !process.env.FIREBASE_SERVICE_ACCOUNT_JSON
-    ) {
+    if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
       throw new Error(
-        'Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON'
+        'Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT'
       );
     }
   }

--- a/scripts/repair-missing-playlist-original.mjs
+++ b/scripts/repair-missing-playlist-original.mjs
@@ -255,9 +255,9 @@ function ensureAdminApp({ projectId, target }) {
     return admin.initializeApp({ projectId });
   }
 
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount?.startsWith('{')) {
+    const parsed = JSON.parse(serviceAccount);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -628,8 +628,8 @@ async function main() {
       throw new Error('Refusing to write to prod: pass --allowProd or set ALLOW_PROD_MIGRATION=1');
     }
 
-    if (!process.env.FIREBASE_SERVICE_ACCOUNT && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON');
+    if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT');
     }
   }
 

--- a/scripts/seed-firestore-fixtures.mjs
+++ b/scripts/seed-firestore-fixtures.mjs
@@ -148,11 +148,9 @@ function ensureAdminApp({ projectId, target }) {
   }
 
   // target === 'prod'
-  // If FIREBASE_SERVICE_ACCOUNT is set, admin SDK picks it up automatically.
-  // Allow service account JSON inline for convenience.
-  const inlineJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
-  if (inlineJson) {
-    const parsed = JSON.parse(inlineJson);
+  const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+  if (serviceAccount?.startsWith('{')) {
+    const parsed = JSON.parse(serviceAccount);
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
       projectId: projectId || parsed.project_id
@@ -197,9 +195,8 @@ async function seed() {
       throw new Error('Refusing to seed prod: set ALLOW_PROD_SEED=1 or pass --allowProd');
     }
 
-    // We allow either FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON.
-    if (!process.env.FIREBASE_SERVICE_ACCOUNT && !process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
-      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_JSON');
+    if (!process.env.FIREBASE_SERVICE_ACCOUNT) {
+      throw new Error('Missing prod credentials: set FIREBASE_SERVICE_ACCOUNT');
     }
   }
 

--- a/src/lib/server/firebaseAdmin.js
+++ b/src/lib/server/firebaseAdmin.js
@@ -8,7 +8,7 @@ let adminFieldValue = null;
 let adminInitialized = false;
 
 function resolveServiceAccount() {
-  const raw = env.FIREBASE_SERVICE_ACCOUNT || env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  const raw = env.FIREBASE_SERVICE_ACCOUNT;
   if (raw?.trim()) {
     const trimmed = raw.trim();
     if (trimmed.startsWith('{')) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -74,6 +74,13 @@
       return;
     }
 
+    // Skip view transitions for same-pathname navigations (e.g. search query param updates)
+    // to prevent focus loss caused by startViewTransition capturing/replacing the DOM
+    const fromPath = navigation.from?.url?.pathname ?? '';
+    if (toPath === fromPath) {
+      return;
+    }
+
     return new Promise((resolve) => {
       document.startViewTransition(async () => {
         resolve();


### PR DESCRIPTION
Unify service-account handling by replacing FIREBASE_SERVICE_ACCOUNT_JSON with FIREBASE_SERVICE_ACCOUNT across docs, Netlify plugin, and scripts. Scripts and server code now read FIREBASE_SERVICE_ACCOUNT (trimmed) and accept either an inline JSON string or a file path (with appropriate parsing and clearer error messages). Also update examples and docs to show the single env var, and adjust various prod-credential checks to require FIREBASE_SERVICE_ACCOUNT. Separately, skip startViewTransition for same-pathname navigations in +layout.svelte to avoid focus loss when only query params change.