### PR TITLE
Support service account file path; add playlistId

### DIFF
--- a/scripts/algolia-index.mjs
+++ b/scripts/algolia-index.mjs
@@ -116,13 +116,9 @@ function ensureAdminApp({ projectId, target }) {
   // target === 'prod'
   const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
   if (serviceAccount) {
-    if (!serviceAccount.startsWith('{')) {
-      throw new Error(
-        'FIREBASE_SERVICE_ACCOUNT must be an inline JSON string in scripts/algolia-index.mjs; file paths are not supported.'
-      );
-    }
-
-    const parsed = JSON.parse(serviceAccount);
+    const parsed = serviceAccount.startsWith('{')
+      ? JSON.parse(serviceAccount)
+      : JSON.parse(fs.readFileSync(path.resolve(process.cwd(), serviceAccount), 'utf8'));
 
     return admin.initializeApp({
       credential: admin.credential.cert(parsed),
@@ -284,6 +280,7 @@ async function indexReactions() {
       'reactionVideoTitle',
       'originalVideoId',
       'originalVideoTitle',
+      'playlistId',
       'reactionVideoAuthor',
       'tags',
       'slug',


### PR DESCRIPTION
Allow FIREBASE_SERVICE_ACCOUNT to be either an inline JSON string or a filesystem path. If the value starts with '{' it is parsed as JSON; otherwise the file at the given path (resolved from cwd) is read and parsed. Also include "playlistId" in the list of fields indexed for reactions.