### PR TITLE
Responsive 3-column layout for reactions pages

### DIFF
--- a/src/lib/components/Video/OtherReactions.svelte
+++ b/src/lib/components/Video/OtherReactions.svelte
@@ -7,9 +7,9 @@
     export let originalVideoId;
     export let reactionVideoId;
     export let originalVideoTitle = "";
-    export let hasReactions = false;
+    export let hasOtherReactions = false;
 
-    $: hasReactions = otherReactions.length > 0;
+    $: hasOtherReactions = otherReactions.length > 0;
 
     let otherReactions = [];
     let itemRefs = [];

--- a/src/lib/components/Video/OtherReactions.svelte
+++ b/src/lib/components/Video/OtherReactions.svelte
@@ -7,6 +7,9 @@
     export let originalVideoId;
     export let reactionVideoId;
     export let originalVideoTitle = "";
+    export let hasReactions = false;
+
+    $: hasReactions = otherReactions.length > 0;
 
     let otherReactions = [];
     let itemRefs = [];
@@ -84,7 +87,12 @@
     }
 
     function handleCarouselKeydown(event) {
-        if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+        if (
+            event.key !== "ArrowRight" &&
+            event.key !== "ArrowLeft" &&
+            event.key !== "ArrowDown" &&
+            event.key !== "ArrowUp"
+        ) {
             return;
         }
 
@@ -105,7 +113,8 @@
         }
 
         event.preventDefault();
-        const direction = event.key === "ArrowRight" ? 1 : -1;
+        const direction =
+            event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
         const nextIndex = Math.min(
             Math.max(currentIndex + direction, 0),
             items.length - 1,
@@ -231,6 +240,21 @@
 
         .carousel-item {
             flex: initial;
+        }
+    }
+
+    @media (min-width: 1024px) {
+        .carousel {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            grid-template-columns: none;
+        }
+
+        .carousel-item {
+            flex: initial;
+            max-width: 100%;
+            width: 100%;
         }
     }
 </style>

--- a/src/routes/playlist/[slug]/+page.svelte
+++ b/src/routes/playlist/[slug]/+page.svelte
@@ -53,6 +53,7 @@
   let playlistSlug = "";
   let playlistDocumentLocal = null;
   let playlistInitError = "";
+  let hasOtherReactions = false;
 
   $: playlistOwnerId = ($state.playlistDocument ?? playlistDocumentLocal)
     ?.userId;
@@ -281,64 +282,76 @@
   />
 
   {#if !$state.isFullscreen}
-    <div class="mx-auto w-full px-4 pt-6 sm:px-6 lg:px-10">
-      <CreatorDetails
-        originalVideoAuthor={$state.originalVideoAuthor}
-        originalVideoAuthorUrl={$state.originalVideoAuthorUrl}
-        originalVideoTitle={$state.originalVideoTitle}
-        originalVideoId={$state.originalVideoId}
-        originalVideoUrl={$state.originalVideoUrl}
-        originalVideoDescription={$state.originalVideoDescription}
-        originalVideoPlatform={$state.originalVideoPlatform}
-        reactionVideoAuthor={$state.reactionVideoAuthor}
-        reactionVideoTitle={$state.reactionVideoTitle}
-        reactionVideoId={$state.reactionVideoId}
-        reactionVideoDescription={$state.reactionVideoDescription}
-        pageSlug={$state.pageSlug}
-        isUsersOwnVideo={$state.isUsersOwnVideo}
-        reactorId={$state.reactorId}
-        reactorDisplayName={$state.reactorDisplayName}
-      />
-      <div class="mt-3 sm:mt-4">
-        <AttributionBlock
-          reactionVideoAuthor={$state.reactionVideoAuthor}
-          reactorDisplayName={$state.reactorDisplayName}
-          reactorId={$state.reactorId}
-        />
-      </div>
+    <div class="mx-auto w-full px-4 pt-6 pb-8 sm:px-6 lg:px-10">
+      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}">
+        <!-- Column 1: Metadata & Playlist Queue -->
+        <div class="flex flex-col gap-6 order-1 lg:order-1">
+          <div>
+            <CreatorDetails
+              originalVideoAuthor={$state.originalVideoAuthor}
+              originalVideoAuthorUrl={$state.originalVideoAuthorUrl}
+              originalVideoTitle={$state.originalVideoTitle}
+              originalVideoId={$state.originalVideoId}
+              originalVideoUrl={$state.originalVideoUrl}
+              originalVideoDescription={$state.originalVideoDescription}
+              originalVideoPlatform={$state.originalVideoPlatform}
+              reactionVideoAuthor={$state.reactionVideoAuthor}
+              reactionVideoTitle={$state.reactionVideoTitle}
+              reactionVideoId={$state.reactionVideoId}
+              reactionVideoDescription={$state.reactionVideoDescription}
+              pageSlug={$state.pageSlug}
+              isUsersOwnVideo={$state.isUsersOwnVideo}
+              reactorId={$state.reactorId}
+              reactorDisplayName={$state.reactorDisplayName}
+            />
+            <div class="mt-3 sm:mt-4">
+              <AttributionBlock
+                reactionVideoAuthor={$state.reactionVideoAuthor}
+                reactorDisplayName={$state.reactorDisplayName}
+                reactorId={$state.reactorId}
+              />
+            </div>
+          </div>
 
-      {#if $state.originalVideoId && playlistSlug}
-        <div class="mt-8">
-          <PlaylistQueue
-            playlistItems={$state.playlistItems}
-            playlistDocument={$state.playlistDocument ?? playlistDocumentLocal}
-            currentlyViewed={$state.originalVideoId}
-            playlistId={$state.youtubePlaylistId}
-            playlistDocumentId={playlistSlug}
-            currentIndex={$state.currentIndexInPlaylist}
-            isCreation={false}
-            onSelect={handlePlaylistSelect}
-          />
+          {#if $state.originalVideoId && playlistSlug}
+            <div class="w-full">
+              <PlaylistQueue
+                playlistItems={$state.playlistItems}
+                playlistDocument={$state.playlistDocument ?? playlistDocumentLocal}
+                currentlyViewed={$state.originalVideoId}
+                playlistId={$state.youtubePlaylistId}
+                playlistDocumentId={playlistSlug}
+                currentIndex={$state.currentIndexInPlaylist}
+                isCreation={false}
+                onSelect={handlePlaylistSelect}
+              />
+            </div>
+          {/if}
         </div>
-      {/if}
-    </div>
 
-    {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
-      <OtherReactions
-        originalVideoId={$state.originalVideoId}
-        reactionVideoId={$state.reactionVideoId}
-      />
-    {/if}
+        <!-- Column 2: YouTube Discussion (Comments) -->
+        <div class="flex flex-col gap-6 order-3 lg:order-2">
+          {#if !$state.isEditModeOn}
+            <YouTubeDiscussion
+              reactionVideoId={$state.reactionVideoId}
+              originalVideoId={$state.originalVideoId}
+              originalVideoPlatform={$state.originalVideoPlatform}
+            />
+          {/if}
+        </div>
 
-    {#if !$state.isEditModeOn}
-      <div class="mx-auto w-full px-4 pb-8 pt-4 sm:px-6 lg:px-10">
-        <YouTubeDiscussion
-          reactionVideoId={$state.reactionVideoId}
-          originalVideoId={$state.originalVideoId}
-          originalVideoPlatform={$state.originalVideoPlatform}
-        />
+        <!-- Column 3: Other Reactions -->
+        {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
+          <div class="flex flex-col gap-6 order-2 lg:order-3 {hasOtherReactions ? 'block' : 'hidden'}">
+            <OtherReactions
+              originalVideoId={$state.originalVideoId}
+              reactionVideoId={$state.reactionVideoId}
+              bind:hasReactions={hasOtherReactions}
+            />
+          </div>
+        {/if}
       </div>
-    {/if}
+    </div>
   {/if}
 </div>
 

--- a/src/routes/playlist/[slug]/+page.svelte
+++ b/src/routes/playlist/[slug]/+page.svelte
@@ -283,9 +283,9 @@
 
   {#if !$state.isFullscreen}
     <div class="mx-auto w-full px-4 pt-6 pb-8 sm:px-6 lg:px-10">
-      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}">
-        <!-- Column 1: Metadata & Playlist Queue -->
-        <div class="flex flex-col gap-6 order-1 lg:order-1">
+      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : ''}">
+        <!-- Row 1, Col 1-2: Metadata & Playlist Queue -->
+        <div class="flex flex-col gap-6 {hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-2' : ''}">
           <div>
             <CreatorDetails
               originalVideoAuthor={$state.originalVideoAuthor}
@@ -329,24 +329,24 @@
           {/if}
         </div>
 
-        <!-- Column 2: YouTube Discussion (Comments) -->
-        <div class="flex flex-col gap-6 order-3 lg:order-2">
-          {#if !$state.isEditModeOn}
-            <YouTubeDiscussion
-              reactionVideoId={$state.reactionVideoId}
-              originalVideoId={$state.originalVideoId}
-              originalVideoPlatform={$state.originalVideoPlatform}
-            />
-          {/if}
-        </div>
-
-        <!-- Column 3: Other Reactions -->
+        <!-- Row 1-2, Col 3: Other Reactions -->
         {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
-          <div class="flex flex-col gap-6 order-2 lg:order-3 {hasOtherReactions ? 'block' : 'hidden'}">
+          <div class="{hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-1 lg:row-span-2' : ''} flex flex-col gap-6 {hasOtherReactions ? 'block' : 'hidden'}">
             <OtherReactions
               originalVideoId={$state.originalVideoId}
               reactionVideoId={$state.reactionVideoId}
               bind:hasReactions={hasOtherReactions}
+            />
+          </div>
+        {/if}
+
+        <!-- Row 2, Col 1-2: YouTube Discussion (Comments) -->
+        {#if !$state.isEditModeOn}
+          <div class="{hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-2' : ''}">
+            <YouTubeDiscussion
+              reactionVideoId={$state.reactionVideoId}
+              originalVideoId={$state.originalVideoId}
+              originalVideoPlatform={$state.originalVideoPlatform}
             />
           </div>
         {/if}

--- a/src/routes/reaction/[slug]/+page.svelte
+++ b/src/routes/reaction/[slug]/+page.svelte
@@ -60,6 +60,7 @@
   let queueHasNext = false;
   let queueHasNextLoading = false;
   let queueHasNextCheckKey = "";
+  let hasOtherReactions = false;
 
   const refreshQueueHasNext = async () => {
     if (!$state.queueSlug) {
@@ -260,7 +261,7 @@
     on:seek={(e) => actions.seekTo(e.detail)}
   />
   {#if !$state.isFullscreen}
-    <div class="mx-auto w-full px-4 pt-6 sm:px-6 lg:px-10" data-testid="reaction-content">
+    <div class="mx-auto w-full px-4 pt-6 pb-8 sm:px-6 lg:px-10" data-testid="reaction-content">
       {#if $state.queueSlug}
         <div class="mb-4 flex items-center justify-between gap-3">
           <div class="min-w-0 overflow-hidden">
@@ -285,66 +286,76 @@
         </div>
       {/if}
 
-      <div data-testid="reaction-metadata">
-        <CreatorDetails
-          originalVideoAuthor={$state.originalVideoAuthor}
-          originalVideoAuthorUrl={$state.originalVideoAuthorUrl}
-          originalVideoTitle={$state.originalVideoTitle}
-          originalVideoId={$state.originalVideoId}
-          originalVideoUrl={$state.originalVideoUrl}
-          originalVideoDescription={$state.originalVideoDescription}
-          originalVideoPlatform={$state.originalVideoPlatform}
-          reactionVideoAuthor={$state.reactionVideoAuthor}
-          reactionVideoTitle={$state.reactionVideoTitle}
-          reactionVideoId={$state.reactionVideoId}
-          reactionVideoDescription={$state.reactionVideoDescription}
-          pageSlug={$state.pageSlug}
-          isUsersOwnVideo={$state.isUsersOwnVideo}
-          reactorId={$state.reactorId}
-          reactorDisplayName={$state.reactorDisplayName}
-        />
-        <div class="mt-3 sm:mt-4">
-          <AttributionBlock
-            reactionVideoAuthor={$state.reactionVideoAuthor}
-            reactorDisplayName={$state.reactorDisplayName}
-            reactorId={$state.reactorId}
-            viewerId={data?.userId}
-          />
-        </div>
-      </div>
+      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}">
+        <!-- Column 1: Metadata & Playlist Queue -->
+        <div class="flex flex-col gap-6 order-1 lg:order-1">
+          <div data-testid="reaction-metadata">
+            <CreatorDetails
+              originalVideoAuthor={$state.originalVideoAuthor}
+              originalVideoAuthorUrl={$state.originalVideoAuthorUrl}
+              originalVideoTitle={$state.originalVideoTitle}
+              originalVideoId={$state.originalVideoId}
+              originalVideoUrl={$state.originalVideoUrl}
+              originalVideoDescription={$state.originalVideoDescription}
+              originalVideoPlatform={$state.originalVideoPlatform}
+              reactionVideoAuthor={$state.reactionVideoAuthor}
+              reactionVideoTitle={$state.reactionVideoTitle}
+              reactionVideoId={$state.reactionVideoId}
+              reactionVideoDescription={$state.reactionVideoDescription}
+              pageSlug={$state.pageSlug}
+              isUsersOwnVideo={$state.isUsersOwnVideo}
+              reactorId={$state.reactorId}
+              reactorDisplayName={$state.reactorDisplayName}
+            />
+            <div class="mt-3 sm:mt-4">
+              <AttributionBlock
+                reactionVideoAuthor={$state.reactionVideoAuthor}
+                reactorDisplayName={$state.reactorDisplayName}
+                reactorId={$state.reactorId}
+                viewerId={data?.userId}
+              />
+            </div>
+          </div>
 
-      {#if $state.originalVideoId && $state.playlistDocumentId}
-        <div class="mt-8">
-          <PlaylistQueue
-            playlistItems={$state.playlistItems}
-            playlistDocument={$state.playlistDocument}
-            currentlyViewed={$state.originalVideoId}
-            playlistId={$state.youtubePlaylistId}
-            playlistDocumentId={$state.playlistDocumentId}
-            currentIndex={$state.currentIndexInPlaylist}
-            isCreation={false}
-          />
+          {#if $state.originalVideoId && $state.playlistDocumentId}
+            <div class="w-full">
+              <PlaylistQueue
+                playlistItems={$state.playlistItems}
+                playlistDocument={$state.playlistDocument}
+                currentlyViewed={$state.originalVideoId}
+                playlistId={$state.youtubePlaylistId}
+                playlistDocumentId={$state.playlistDocumentId}
+                currentIndex={$state.currentIndexInPlaylist}
+                isCreation={false}
+              />
+            </div>
+          {/if}
         </div>
-      {/if}
+
+        <!-- Column 2: YouTube Discussion (Comments) -->
+        <div class="flex flex-col gap-6 order-3 lg:order-2">
+          {#if !$state.isEditModeOn}
+            <YouTubeDiscussion
+              reactionVideoId={$state.reactionVideoId}
+              originalVideoId={$state.originalVideoId}
+              originalVideoPlatform={$state.originalVideoPlatform}
+            />
+          {/if}
+        </div>
+
+        <!-- Column 3: Other Reactions -->
+        {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
+          <div class="flex flex-col gap-6 order-2 lg:order-3 {hasOtherReactions ? 'block' : 'hidden'}">
+            <OtherReactions
+              originalVideoId={$state.originalVideoId}
+              reactionVideoId={$state.reactionVideoId}
+              originalVideoTitle={$state.originalVideoTitle}
+              bind:hasReactions={hasOtherReactions}
+            />
+          </div>
+        {/if}
+      </div>
     </div>
-
-    {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
-      <OtherReactions
-        originalVideoId={$state.originalVideoId}
-        reactionVideoId={$state.reactionVideoId}
-        originalVideoTitle={$state.originalVideoTitle}
-      />
-    {/if}
-
-    {#if !$state.isEditModeOn}
-      <div class="mx-auto w-full px-4 pb-8 pt-4 sm:px-6 lg:px-10">
-        <YouTubeDiscussion
-          reactionVideoId={$state.reactionVideoId}
-          originalVideoId={$state.originalVideoId}
-          originalVideoPlatform={$state.originalVideoPlatform}
-        />
-      </div>
-    {/if}
   {/if}
 </div>
 

--- a/src/routes/reaction/[slug]/+page.svelte
+++ b/src/routes/reaction/[slug]/+page.svelte
@@ -286,9 +286,9 @@
         </div>
       {/if}
 
-      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}">
-        <!-- Column 1: Metadata & Playlist Queue -->
-        <div class="flex flex-col gap-6 order-1 lg:order-1">
+      <div class="grid grid-cols-1 gap-8 items-start mt-6 w-full {hasOtherReactions && !$state.isEditModeOn ? 'lg:grid-cols-3' : ''}">
+        <!-- Row 1, Col 1-2: Metadata & Playlist Queue -->
+        <div class="flex flex-col gap-6 {hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-2' : ''}">
           <div data-testid="reaction-metadata">
             <CreatorDetails
               originalVideoAuthor={$state.originalVideoAuthor}
@@ -332,25 +332,25 @@
           {/if}
         </div>
 
-        <!-- Column 2: YouTube Discussion (Comments) -->
-        <div class="flex flex-col gap-6 order-3 lg:order-2">
-          {#if !$state.isEditModeOn}
-            <YouTubeDiscussion
-              reactionVideoId={$state.reactionVideoId}
-              originalVideoId={$state.originalVideoId}
-              originalVideoPlatform={$state.originalVideoPlatform}
-            />
-          {/if}
-        </div>
-
-        <!-- Column 3: Other Reactions -->
+        <!-- Row 1-2, Col 3: Other Reactions -->
         {#if !$state.isEditModeOn && $state.originalVideoId && $state.reactionVideoId}
-          <div class="flex flex-col gap-6 order-2 lg:order-3 {hasOtherReactions ? 'block' : 'hidden'}">
+          <div class="{hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-1 lg:row-span-2' : ''} flex flex-col gap-6 {hasOtherReactions ? 'block' : 'hidden'}">
             <OtherReactions
               originalVideoId={$state.originalVideoId}
               reactionVideoId={$state.reactionVideoId}
               originalVideoTitle={$state.originalVideoTitle}
               bind:hasReactions={hasOtherReactions}
+            />
+          </div>
+        {/if}
+
+        <!-- Row 2, Col 1-2: YouTube Discussion (Comments) -->
+        {#if !$state.isEditModeOn}
+          <div class="{hasOtherReactions && !$state.isEditModeOn ? 'lg:col-span-2' : ''}">
+            <YouTubeDiscussion
+              reactionVideoId={$state.reactionVideoId}
+              originalVideoId={$state.originalVideoId}
+              originalVideoPlatform={$state.originalVideoPlatform}
             />
           </div>
         {/if}


### PR DESCRIPTION
Rework reactions/playlist page layouts into a responsive 3-column grid and wire up OtherReactions visibility.

- src/lib/components/Video/OtherReactions.svelte: add export let hasReactions and a reactive assignment (hasReactions = otherReactions.length > 0); extend keyboard navigation to support ArrowUp/ArrowDown and adjust direction logic; add desktop CSS to render the carousel as a vertical column.
- src/routes/playlist/[slug]/+page.svelte and src/routes/reaction/[slug]/+page.svelte: introduce hasOtherReactions state, restructure markup so metadata/playlist, YouTubeDiscussion, and OtherReactions live in separate responsive columns; bind OtherReactions' hasReactions to parent hasOtherReactions and conditionally show/hide the third column based on that and edit mode; move PlaylistQueue into the first column and add small padding tweaks.

These changes improve layout on large screens (3 columns when other reactions exist) while preserving the previous single-column behaviour on smaller viewports and hiding the OtherReactions column when there are no items.