### PR TITLE
Add Moments: discovery, reactions, and validation

### DIFF
--- a/docs/SCHEMA_REFERENCE.md
+++ b/docs/SCHEMA_REFERENCE.md
@@ -103,6 +103,41 @@ Optional enrichment payloads populated by the server-side metadata enrichment fl
 | `reactorId` | string | No | Reactor's Firebase Auth user ID |
 | `reactorDisplayName` | string | No | Reactor's display name (from Auth profile) |
 
+#### Moments fields (on `reactions`)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `isMomentReaction` | boolean | No | When true, this reaction is a moment reaction (≤60s subsection) |
+| `momentId` | string | No | Firestore document ID of the parent moment anchor |
+| `momentOriginalTimeSeconds` | number | No | Original-content timestamp (seconds) the moment reaction must reach during its subsection |
+
+**Publishing rule:** moment reactions cannot publish unless subsection duration ≤ 60s and synchronized original playback reaches `momentOriginalTimeSeconds` at least once within `[offsetStartTime, reactionFinishTime]`. Enforced client-side via `validateMomentReaction`.
+
+---
+
+### `moments` (COLLECTION_MOMENTS)
+
+Discoverable emotional/event anchors on original content. A moment is not a clip; it is a shared timestamp reference that many moment reactions can attach to.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | Yes | Human-readable moment title (e.g. "Will Ramos Snorting Scream") |
+| `slug` | string | No | URL-friendly identifier (falls back to doc ID in routes) |
+| `originalVideoId` | string | Yes | Platform-native ID of the original video |
+| `originalVideoPlatform` | string | No | `youtube` or `tiktok` (default `youtube`) |
+| `originalVideoTitle` | string | Yes | Snapshot title for discovery UI |
+| `originalVideoAuthor` | string | No | Creator/channel label snapshot |
+| `originalVideoUrl` | string | No | Canonical original URL |
+| `momentTimeSeconds` | number | Yes | Anchor time in original content (seconds) |
+| `tags` | array[string] | No | Discovery tags/categories |
+| `reactionCount` | number | No | Denormalized count of published moment reactions (maintained on publish/unpublish) |
+| `creatorId` | string | Yes | Firebase Auth UID of creator |
+| `creatorDisplayName` | string | No | Creator display name snapshot |
+| `createdAt` | Timestamp | Yes | Creation timestamp |
+| `updatedAt` | Timestamp | Yes | Last update timestamp |
+
+**Note:** Moments do not have `isPublished`; they are visible in discovery immediately after creation.
+
 ---
 
 ### `userData` (COLLECTION_USER_DATA)
@@ -462,6 +497,7 @@ const docRef = await addDoc(collection(db, 'reactions'), {
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.8 | 2026-05-22 | Added `moments` collection, moment reaction fields on `reactions`, discovery routes (`/moments`), and Algolia moments index env `PUBLIC_ALGOLIA_MOMENTS_INDEX` |
 | 1.7 | 2026-04-22 | Documented unified overlay snapshot timeline schema (`overlayVisibilityTimeline` now stores `visible` + `primary`) and static `fullscreenPrimaryVideo` fallback semantics |
 | 1.6 | 2026-04-21 | Documented Realtime Database shared-session access pattern, anonymous viewer auth, and aligned shared-session field names with the live implementation |
 | 1.5 | 2026-04-18 | Added YouTube Discussion Mirror API response schema (`/api/youtube/comments/[videoId]`) — see `docs/YOUTUBE_DISCUSSION_MIRROR.md` |

--- a/firestore.rules
+++ b/firestore.rules
@@ -80,6 +80,14 @@ service cloud.firestore {
       return isSignedIn() && request.resource.data.userId == request.auth.uid;
     }
 
+    function isMomentOwner() {
+      return isSignedIn() && resource.data.creatorId == request.auth.uid;
+    }
+
+    function isMomentOwnerCreate() {
+      return isSignedIn() && request.resource.data.creatorId == request.auth.uid;
+    }
+
     function isQueueOwner() {
       return isSignedIn() && resource.data.ownerId == request.auth.uid;
     }
@@ -185,6 +193,26 @@ service cloud.firestore {
       allow update, delete: if isReactionOwner() &&
         request.resource.data.reactorId == resource.data.reactorId &&
         reactionUpdateHasNoSensitiveKeys();
+    }
+
+    // Moments (public read; owner write)
+    match /moments/{momentId} {
+      allow read: if true;
+      allow create: if isMomentOwnerCreate();
+      allow update, delete: if isMomentOwner() &&
+        request.resource.data.creatorId == resource.data.creatorId;
+    }
+    match /moments-local/{momentId} {
+      allow read: if true;
+      allow create: if isMomentOwnerCreate();
+      allow update, delete: if isMomentOwner() &&
+        request.resource.data.creatorId == resource.data.creatorId;
+    }
+    match /moments-prod/{momentId} {
+      allow read: if true;
+      allow create: if isMomentOwnerCreate();
+      allow update, delete: if isMomentOwner() &&
+        request.resource.data.creatorId == resource.data.creatorId;
     }
 
     // User data (private to the user)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "algolia:status": "node scripts/algolia-status.mjs",
     "algolia:index": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/algolia-index.mjs",
     "algolia:index:apply": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/algolia-index.mjs --apply",
+    "algolia:index:moments": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/algolia-index-moments.mjs",
+    "algolia:index:moments:apply": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/algolia-index-moments.mjs --apply",
     "approve:claim": "node scripts/approve-channel-claim.mjs",
     "admin:reassign-reaction": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/reassign-reaction.mjs",
     "admin:reassign-reaction:dry": "cross-env FIREBASE_SERVICE_ACCOUNT=./secrets/pure-reactions-cb457c74bbbf.json node scripts/reassign-reaction.mjs --dry",

--- a/scripts/algolia-index-moments.mjs
+++ b/scripts/algolia-index-moments.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+/**
+ * Index Firestore moments into Algolia.
+ *
+ * Usage:
+ *   node scripts/algolia-index-moments.mjs
+ *   node scripts/algolia-index-moments.mjs --apply
+ */
+
+import algoliasearch from 'algoliasearch';
+import admin from 'firebase-admin';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+function parseArgs(argv) {
+  const args = { apply: false, batchSize: 500, target: 'prod' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    if (token === '--apply') args.apply = true;
+    if (token === '--target' && next) {
+      args.target = next;
+      i += 1;
+    }
+    if (token === '--batchSize' && next) {
+      args.batchSize = Number(next);
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function loadDotEnvIfPresent(envPath = '.env') {
+  const abs = path.resolve(process.cwd(), envPath);
+  if (!fs.existsSync(abs)) return;
+  const raw = fs.readFileSync(abs, 'utf8');
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+function momentToAlgoliaRecord(docId, data) {
+  return {
+    objectID: docId,
+    title: data.title || '',
+    slug: data.slug || docId,
+    originalVideoId: data.originalVideoId || '',
+    originalVideoTitle: data.originalVideoTitle || '',
+    originalVideoAuthor: data.originalVideoAuthor || '',
+    originalVideoThumbnailUrl: data.originalVideoThumbnailUrl || '',
+    originalVideoPlatform: data.originalVideoPlatform || 'youtube',
+    momentTimeSeconds: Number(data.momentTimeSeconds) || 0,
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    reactionCount: Number(data.reactionCount) || 0,
+    creatorId: data.creatorId || '',
+    creatorDisplayName: data.creatorDisplayName || '',
+    createdAt: data.createdAt?.toMillis?.() || Date.now(),
+    updatedAt: data.updatedAt?.toMillis?.() || Date.now()
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  loadDotEnvIfPresent('.env');
+
+  const appId = process.env.PUBLIC_ALGOLIA_APP_ID;
+  const adminKey = process.env.ALGOLIA_ADMIN_KEY;
+  const indexName = process.env.PUBLIC_ALGOLIA_MOMENTS_INDEX;
+
+  if (!appId || !adminKey || !indexName) {
+    throw new Error(
+      'Missing Algolia config: PUBLIC_ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY, PUBLIC_ALGOLIA_MOMENTS_INDEX'
+    );
+  }
+
+  const projectId =
+    process.env.FIREBASE_PROJECT_ID || process.env.PUBLIC_FIREBASE_PROJECT_ID || 'pure-reactions';
+  const collection = process.env.PUBLIC_FIREBASE_COLLECTION_MOMENTS || 'moments_local';
+
+  if (!admin.apps.length) {
+    if (args.target === 'emulator') {
+      admin.initializeApp({ projectId });
+    } else {
+      const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT?.trim();
+      if (!serviceAccount) {
+        throw new Error('FIREBASE_SERVICE_ACCOUNT is required for prod indexing');
+      }
+      const parsed = serviceAccount.startsWith('{')
+        ? JSON.parse(serviceAccount)
+        : JSON.parse(fs.readFileSync(path.resolve(process.cwd(), serviceAccount), 'utf8'));
+      admin.initializeApp({ credential: admin.credential.cert(parsed), projectId });
+    }
+  }
+
+  const db = admin.firestore();
+  const snapshot = await db.collection(collection).get();
+  const records = snapshot.docs.map((doc) => momentToAlgoliaRecord(doc.id, doc.data()));
+
+  console.log(`Prepared ${records.length} moment records for index "${indexName}"`);
+
+  if (!args.apply) {
+    console.log('Dry run complete. Re-run with --apply to push records.');
+    return;
+  }
+
+  const client = algoliasearch(appId, adminKey);
+  const index = client.initIndex(indexName);
+  await index.saveObjects(records);
+  console.log(`Indexed ${records.length} moments.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/lib/components/Moments/MomentChrome.svelte
+++ b/src/lib/components/Moments/MomentChrome.svelte
@@ -1,0 +1,56 @@
+<script>
+  import { goto } from '$app/navigation';
+  import { PlusOutline, VideoCameraOutline } from 'flowbite-svelte-icons';
+  import CinematicButton from '$lib/components/design-system/CinematicButton.svelte';
+
+  export let momentId = '';
+  export let momentTitle = '';
+  export let reactionCount = 0;
+  export let onAddReaction = () => {};
+  export let addReactionLoading = false;
+
+  const goCreateMoment = () => goto('/moments/new');
+</script>
+
+<header
+  class="pointer-events-none absolute inset-x-0 top-0 z-30 flex items-start justify-between gap-3 bg-gradient-to-b from-black/70 to-transparent px-4 pb-10 pt-4 sm:px-6"
+>
+  <div class="pointer-events-auto min-w-0 flex-1">
+    <a
+      href="/moments"
+      class="text-xs font-medium uppercase tracking-wide text-white/70 transition hover:text-white"
+    >
+      Moments
+    </a>
+    <h1 class="mt-1 line-clamp-2 text-lg font-semibold text-white sm:text-xl">{momentTitle}</h1>
+    <p class="mt-1 text-sm text-white/70">
+      {reactionCount} synced {reactionCount === 1 ? 'reaction' : 'reactions'}
+    </p>
+  </div>
+
+  <div class="pointer-events-auto flex shrink-0 flex-col gap-2">
+    <CinematicButton
+      type="button"
+      variant="secondary"
+      class="!px-3 !py-2 text-xs sm:text-sm"
+      disabled={addReactionLoading || !momentId}
+      on:click={onAddReaction}
+    >
+      <span class="inline-flex items-center gap-2">
+        <PlusOutline class="h-4 w-4" aria-hidden="true" />
+        {addReactionLoading ? 'Starting…' : 'Add reaction'}
+      </span>
+    </CinematicButton>
+    <CinematicButton
+      type="button"
+      variant="ghost"
+      class="!px-3 !py-2 text-xs text-white/90 sm:text-sm"
+      on:click={goCreateMoment}
+    >
+      <span class="inline-flex items-center gap-2">
+        <VideoCameraOutline class="h-4 w-4" aria-hidden="true" />
+        New moment
+      </span>
+    </CinematicButton>
+  </div>
+</header>

--- a/src/lib/components/Moments/MomentDiscoveryCard.svelte
+++ b/src/lib/components/Moments/MomentDiscoveryCard.svelte
@@ -1,0 +1,61 @@
+<script>
+  import { buildYouTubeThumbnailUrl } from '$lib/helpers/originalVideo';
+  import { buildMomentPagePath } from '$lib/helpers/momentsFirestore';
+
+  export let moment = {};
+
+  $: momentId = moment.objectID || moment.id;
+  $: href = buildMomentPagePath(momentId);
+  $: title = moment.title || 'Untitled moment';
+  $: originalTitle = moment.originalVideoTitle || 'Original video';
+  $: reactionCount = Number(moment.reactionCount) || 0;
+  $: thumbnail =
+    moment.originalVideoThumbnailUrl ||
+    buildYouTubeThumbnailUrl(moment.originalVideoId) ||
+    '';
+  $: tags = Array.isArray(moment.tags) ? moment.tags.slice(0, 3) : [];
+</script>
+
+<article class="group flex h-full flex-col overflow-hidden rounded-2xl border border-border-strong/40 bg-surface/80 shadow-surface transition duration-300 ease-cinematic hover:border-border-strong/70 hover:shadow-elevated">
+  <a
+    {href}
+    class="relative block aspect-video overflow-hidden bg-background/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    aria-label={`Open moment: ${title}`}
+  >
+    {#if thumbnail}
+      <img
+        src={thumbnail}
+        alt=""
+        class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.02]"
+        loading="lazy"
+        decoding="async"
+      />
+    {:else}
+      <div class="flex h-full items-center justify-center text-sm text-text-muted">No preview</div>
+    {/if}
+    <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-4 py-3">
+      <p class="text-xs uppercase tracking-wide text-white/70">Original</p>
+      <p class="line-clamp-1 text-sm font-medium text-white">{originalTitle}</p>
+    </div>
+  </a>
+
+  <div class="flex flex-1 flex-col gap-3 p-4">
+    <a {href} class="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus rounded-sm">
+      <h2 class="line-clamp-2 text-lg font-semibold text-text-primary group-hover:text-white">
+        {title}
+      </h2>
+    </a>
+
+    <p class="text-sm text-text-secondary">
+      {reactionCount} {reactionCount === 1 ? 'reaction' : 'reactions'}
+    </p>
+
+    {#if tags.length}
+      <ul class="flex flex-wrap gap-2" aria-label="Tags">
+        {#each tags as tag}
+          <li class="rounded-full bg-background/80 px-2.5 py-0.5 text-xs text-text-muted">{tag}</li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</article>

--- a/src/lib/components/Moments/MomentPlayGate.svelte
+++ b/src/lib/components/Moments/MomentPlayGate.svelte
@@ -1,0 +1,25 @@
+<script>
+  import CinematicButton from '$lib/components/design-system/CinematicButton.svelte';
+
+  export let visible = false;
+  export let onPlay = () => {};
+</script>
+
+{#if visible}
+  <div
+    class="absolute inset-0 z-20 flex items-center justify-center bg-black/55 px-6 backdrop-blur-[2px]"
+    role="presentation"
+  >
+    <div class="max-w-sm text-center">
+      <p class="text-lg font-semibold text-white">Watch this moment</p>
+      <p class="mt-2 text-sm text-white/75">
+        Tap play to start synchronized playback. Swiping to more reactions will continue automatically.
+      </p>
+      <div class="mt-6 flex justify-center">
+        <CinematicButton type="button" variant="primary" on:click={onPlay}>
+          Play moment reaction
+        </CinematicButton>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/Navigation/TopNavigation.svelte
+++ b/src/lib/components/Navigation/TopNavigation.svelte
@@ -54,6 +54,12 @@
 
     <!-- Desktop Navigation Links -->
     <div class="hidden items-center gap-6 md:flex">
+      <a
+        href="/moments"
+        class="text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
+      >
+        Moments
+      </a>
       <button
         type="button"
         class="inline-flex items-center gap-2 rounded-full border border-border-strong/60 bg-surface/70 px-4 py-2 text-sm font-medium text-text-primary shadow-surface transition-all duration-300 ease-cinematic hover:bg-surface/90 hover:shadow-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"

--- a/src/lib/composables/useTwinPlayers.ts
+++ b/src/lib/composables/useTwinPlayers.ts
@@ -63,6 +63,7 @@ type UseTwinPlayersOptions = {
     displayName?: string | null;
   };
   enableAutoPlay?: boolean;
+  momentFeedLoopEnabled?: boolean;
 };
 
 export const CONTROLS_FADE_CLASS = 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100';
@@ -71,7 +72,11 @@ export const CONTROLS_FADE_CLASS = 'opacity-0 group-hover:opacity-100 group-focu
 const ENABLE_GATE_DEBUG = false;
 const ENABLE_WATCHDOG = false;
 
-export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOptions) {
+export function useTwinPlayers({
+  data,
+  enableAutoPlay = true,
+  momentFeedLoopEnabled = false
+}: UseTwinPlayersOptions) {
   const { slug, userId } = data;
 
   if (typeof window !== 'undefined') {
@@ -118,7 +123,8 @@ export function useTwinPlayers({ data, enableAutoPlay = true }: UseTwinPlayersOp
     queueIndex: Number.isFinite(initialUrlState.queueIndex as number) ? (initialUrlState.queueIndex as number) : 0,
     isQueueAutoPlay: Boolean(initialUrlState.queueAutoPlay),
     showCinematicBars: readCinematicBarsCookie(),
-    isFullscreen: initialUrlState.isFullscreen
+    isFullscreen: initialUrlState.isFullscreen,
+    momentFeedLoopEnabled
   });
 
   let initSeq = 0;

--- a/src/lib/constants/algolia.js
+++ b/src/lib/constants/algolia.js
@@ -1,3 +1,4 @@
 import { env } from '$env/dynamic/public';
 
 export const ALGOLIA_REACTIONS_INDEX = env.PUBLIC_ALGOLIA_REACTIONS_INDEX;
+export const ALGOLIA_MOMENTS_INDEX = env.PUBLIC_ALGOLIA_MOMENTS_INDEX;

--- a/src/lib/constants/firebase.js
+++ b/src/lib/constants/firebase.js
@@ -13,6 +13,7 @@ export const COLLECTION_REACTION_BINOMES = readCollectionName(env.PUBLIC_FIREBAS
 export const COLLECTION_USER_DATA = readCollectionName(env.PUBLIC_FIREBASE_COLLECTION_USER_DATA, 'userData_local');
 export const COLLECTION_PLAYLISTS = readCollectionName(env.PUBLIC_FIREBASE_COLLECTION_PLAYLISTS, 'playlists_local');
 export const COLLECTION_QUEUES = readCollectionName(env.PUBLIC_FIREBASE_COLLECTION_QUEUES, 'queues_local');
+export const COLLECTION_MOMENTS = readCollectionName(env.PUBLIC_FIREBASE_COLLECTION_MOMENTS, 'moments_local');
 export const COLLECTION_YOUTUBE_CHANNEL_CLAIMS = readCollectionName(env.PUBLIC_FIREBASE_COLLECTION_YOUTUBE_CHANNEL_CLAIMS, 'youtubeChannelClaims_local');
 const DEFAULT_YOUTUBE_CHANNEL_VERIFICATIONS = COLLECTION_YOUTUBE_CHANNEL_CLAIMS
     ? COLLECTION_YOUTUBE_CHANNEL_CLAIMS.replace('youtubeChannelClaims', 'youtubeChannelVerifications')

--- a/src/lib/constants/moments.js
+++ b/src/lib/constants/moments.js
@@ -1,0 +1,13 @@
+export const MOMENT_SORT_OPTIONS = {
+  NEWEST: 'newest',
+  TRENDING: 'trending',
+  MOST_REACTIONS: 'most-reactions'
+};
+
+export const MOMENT_SORT_LABELS = {
+  [MOMENT_SORT_OPTIONS.NEWEST]: 'Newest',
+  [MOMENT_SORT_OPTIONS.TRENDING]: 'Trending',
+  [MOMENT_SORT_OPTIONS.MOST_REACTIONS]: 'Most reactions'
+};
+
+export const DEFAULT_MOMENT_SORT = MOMENT_SORT_OPTIONS.NEWEST;

--- a/src/lib/helpers/firebase.js
+++ b/src/lib/helpers/firebase.js
@@ -34,6 +34,7 @@ import {
     COLLECTION_USER_DATA,
     COLLECTION_PLAYLISTS,
     COLLECTION_QUEUES,
+    COLLECTION_MOMENTS,
     COLLECTION_YOUTUBE_CHANNEL_CLAIMS,
     COLLECTION_YOUTUBE_CHANNEL_VERIFICATIONS,
     app, db, auth, database
@@ -181,6 +182,165 @@ export const createReactionDocument = async ({
     } catch (error) {
         console.error("Error adding document:", error);
         throw error; // Ensure errors are properly propagated
+    }
+};
+
+export const createMomentDocument = async ({
+    title,
+    slug,
+    originalVideoId,
+    originalVideoTitle,
+    originalVideoPlatform = 'youtube',
+    originalVideoAuthor,
+    originalVideoAuthorHandle,
+    originalVideoAuthorUrl,
+    originalVideoDescription,
+    originalVideoThumbnailUrl,
+    originalVideoThumbnailWidth,
+    originalVideoThumbnailHeight,
+    originalVideoProviderName,
+    originalVideoProviderUrl,
+    originalVideoUrl,
+    momentTimeSeconds,
+    tags = [],
+    creatorId,
+    creatorDisplayName = ''
+}) => {
+    try {
+        const momentsCollection = createCollection(db, COLLECTION_MOMENTS, 'createMomentDocument');
+        const dataToAdd = {
+            title: title?.trim?.() || 'Untitled moment',
+            slug: slug?.trim?.() || '',
+            originalVideoId,
+            originalVideoTitle: originalVideoTitle?.trim?.() || '',
+            originalVideoPlatform: originalVideoPlatform || 'youtube',
+            momentTimeSeconds: Number(momentTimeSeconds),
+            tags: Array.isArray(tags) ? tags : [],
+            reactionCount: 0,
+            creatorId,
+            creatorDisplayName: creatorDisplayName?.trim?.() || '',
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        };
+
+        if (typeof originalVideoAuthor === 'string' && originalVideoAuthor.trim()) {
+            dataToAdd.originalVideoAuthor = originalVideoAuthor.trim();
+        }
+        if (typeof originalVideoAuthorHandle === 'string' && originalVideoAuthorHandle.trim()) {
+            dataToAdd.originalVideoAuthorHandle = originalVideoAuthorHandle.trim();
+        }
+        if (typeof originalVideoAuthorUrl === 'string' && originalVideoAuthorUrl.trim()) {
+            dataToAdd.originalVideoAuthorUrl = originalVideoAuthorUrl.trim();
+        }
+        if (typeof originalVideoDescription === 'string' && originalVideoDescription.trim()) {
+            dataToAdd.originalVideoDescription = originalVideoDescription.trim();
+        }
+        if (typeof originalVideoThumbnailUrl === 'string' && originalVideoThumbnailUrl.trim()) {
+            dataToAdd.originalVideoThumbnailUrl = originalVideoThumbnailUrl.trim();
+        }
+        if (typeof originalVideoThumbnailWidth === 'number' && Number.isFinite(originalVideoThumbnailWidth)) {
+            dataToAdd.originalVideoThumbnailWidth = originalVideoThumbnailWidth;
+        }
+        if (typeof originalVideoThumbnailHeight === 'number' && Number.isFinite(originalVideoThumbnailHeight)) {
+            dataToAdd.originalVideoThumbnailHeight = originalVideoThumbnailHeight;
+        }
+        if (typeof originalVideoProviderName === 'string' && originalVideoProviderName.trim()) {
+            dataToAdd.originalVideoProviderName = originalVideoProviderName.trim();
+        }
+        if (typeof originalVideoProviderUrl === 'string' && originalVideoProviderUrl.trim()) {
+            dataToAdd.originalVideoProviderUrl = originalVideoProviderUrl.trim();
+        }
+        if (typeof originalVideoUrl === 'string' && originalVideoUrl.trim()) {
+            dataToAdd.originalVideoUrl = originalVideoUrl.trim();
+        }
+
+        const documentRef = await addDoc(momentsCollection, dataToAdd);
+        return documentRef.id;
+    } catch (error) {
+        console.error('Error creating moment document:', error);
+        throw error;
+    }
+};
+
+export const createMomentReactionDocument = async ({
+    momentId,
+    momentOriginalTimeSeconds,
+    originalVideoId,
+    userId,
+    originalVideoAuthor,
+    originalVideoAuthorHandle,
+    originalVideoAuthorUrl,
+    originalVideoTitle,
+    originalVideoDescription,
+    originalVideoThumbnailUrl,
+    originalVideoThumbnailWidth,
+    originalVideoThumbnailHeight,
+    originalVideoProviderName,
+    originalVideoProviderUrl,
+    originalVideoUrl,
+    originalVideoPlatform,
+    offsetStartTime = 0
+}) => {
+    try {
+        const reactorDisplayName = auth?.currentUser?.displayName?.trim?.() || '';
+        const reactionsCollection = createCollection(db, COLLECTION_REACTION_BINOMES, 'createMomentReactionDocument');
+        const dataToAdd = {
+            originalVideoId,
+            originalVideoAuthor,
+            originalVideoTitle,
+            originalVideoPlatform: originalVideoPlatform || 'youtube',
+            reactionConfigs: {},
+            playbackRateConfigs: {},
+            reactorId: userId,
+            reactorDisplayName,
+            offsetStartTime,
+            fullscreenPrimaryVideo: 'original',
+            fullscreenOverlayWidthPercent: 35,
+            fullscreenOverlayCorner: 'top-right',
+            isMomentReaction: true,
+            momentId,
+            momentOriginalTimeSeconds: Number(momentOriginalTimeSeconds),
+            isPublished: false,
+            createdAt: serverTimestamp()
+        };
+
+        if (typeof originalVideoAuthorHandle === 'string' && originalVideoAuthorHandle.trim()) {
+            dataToAdd.originalVideoAuthorHandle = originalVideoAuthorHandle.trim();
+        }
+        if (typeof originalVideoAuthorUrl === 'string' && originalVideoAuthorUrl.trim()) {
+            dataToAdd.originalVideoAuthorUrl = originalVideoAuthorUrl.trim();
+        }
+        if (typeof originalVideoDescription === 'string' && originalVideoDescription.trim()) {
+            dataToAdd.originalVideoDescription = originalVideoDescription.trim();
+        }
+        if (typeof originalVideoThumbnailUrl === 'string' && originalVideoThumbnailUrl.trim()) {
+            dataToAdd.originalVideoThumbnailUrl = originalVideoThumbnailUrl.trim();
+        }
+        if (typeof originalVideoThumbnailWidth === 'number' && Number.isFinite(originalVideoThumbnailWidth)) {
+            dataToAdd.originalVideoThumbnailWidth = originalVideoThumbnailWidth;
+        }
+        if (typeof originalVideoThumbnailHeight === 'number' && Number.isFinite(originalVideoThumbnailHeight)) {
+            dataToAdd.originalVideoThumbnailHeight = originalVideoThumbnailHeight;
+        }
+        if (typeof originalVideoProviderName === 'string' && originalVideoProviderName.trim()) {
+            dataToAdd.originalVideoProviderName = originalVideoProviderName.trim();
+        }
+        if (typeof originalVideoProviderUrl === 'string' && originalVideoProviderUrl.trim()) {
+            dataToAdd.originalVideoProviderUrl = originalVideoProviderUrl.trim();
+        }
+        if (typeof originalVideoUrl === 'string' && originalVideoUrl.trim()) {
+            dataToAdd.originalVideoUrl = originalVideoUrl.trim();
+        }
+
+        const documentRef = await addDoc(reactionsCollection, dataToAdd);
+        window.currentReactionDocumentId = documentRef.id;
+        requestReactionEnrichment(documentRef.id).catch((error) => {
+            console.error('Failed to enqueue reaction enrichment', error);
+        });
+        return documentRef.id;
+    } catch (error) {
+        console.error('Error creating moment reaction document:', error);
+        throw error;
     }
 };
 

--- a/src/lib/helpers/momentReactionValidation.ts
+++ b/src/lib/helpers/momentReactionValidation.ts
@@ -1,0 +1,234 @@
+import {
+  getCurrentStateFromStateConfigs,
+  integratePlaybackRate
+} from '$lib/helpers/reaction';
+import { deriveTimelines } from '$lib/helpers/reactionPlayer';
+
+/** Maximum allowed reaction subsection length for a moment reaction (seconds). */
+export const MOMENT_REACTION_MAX_DURATION_SECONDS = 60;
+
+/** Tolerance when checking whether original playback reached the moment anchor time. */
+export const MOMENT_ORIGINAL_TIME_TOLERANCE_SECONDS = 0.75;
+
+const YT_PLAYING_STATE = 1;
+
+export type MomentReactionValidationInput = {
+  momentOriginalTimeSeconds: number;
+  offsetStartTime?: number;
+  reactionFinishTime?: number;
+  reactionDurationSeconds?: number;
+  timeOffset?: number;
+  playerConfigs?: unknown;
+  stateTimeline?: unknown;
+  playbackRateTimeline?: unknown;
+  reactionData?: Record<string, unknown>;
+};
+
+export type MomentReactionValidationResult = {
+  ok: boolean;
+  errors: string[];
+  subsectionDurationSeconds: number | null;
+  originalTimeRange: { min: number; max: number } | null;
+};
+
+export function getOriginalTimeAtReactionTime(
+  reactionTime: number,
+  {
+    stateTimeline,
+    playerConfigs,
+    timeOffset = 0,
+    playbackRateTimeline = []
+  }: {
+    stateTimeline?: unknown;
+    playerConfigs?: unknown;
+    timeOffset?: number;
+    playbackRateTimeline?: unknown;
+  }
+): number {
+  const timeline = stateTimeline ?? playerConfigs ?? [];
+  const config = getCurrentStateFromStateConfigs(reactionTime, timeline, timeOffset);
+  const desiredState = Number(config.state);
+  const baseTargetTime = Number(config.time ?? 0);
+  const anchorTime = Number(config.closestSmallerTimeCode ?? reactionTime);
+
+  let targetTime = Number.isFinite(baseTargetTime) ? baseTargetTime : 0;
+
+  if (
+    desiredState === YT_PLAYING_STATE &&
+    Number.isFinite(anchorTime) &&
+    Number.isFinite(reactionTime)
+  ) {
+    const timeOffsetAdjustedReactionTime = reactionTime - Number(timeOffset || 0);
+    targetTime += integratePlaybackRate(
+      anchorTime,
+      timeOffsetAdjustedReactionTime,
+      Array.isArray(playbackRateTimeline) ? playbackRateTimeline : []
+    );
+  }
+
+  return targetTime;
+}
+
+const collectSubsectionSampleTimes = (
+  start: number,
+  end: number,
+  stateTimeline: unknown
+): number[] => {
+  const samples = new Set<number>([start, end]);
+
+  if (Array.isArray(stateTimeline)) {
+    for (const entry of stateTimeline) {
+      const t = Number(entry?.t);
+      if (Number.isFinite(t) && t >= start && t <= end) {
+        samples.add(t);
+      }
+    }
+  } else if (stateTimeline && typeof stateTimeline === 'object') {
+    for (const key of Object.keys(stateTimeline)) {
+      const t = Number(key);
+      if (Number.isFinite(t) && t >= start && t <= end) {
+        samples.add(t);
+      }
+    }
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  for (let i = 0; i < sorted.length - 1; i += 1) {
+    samples.add((sorted[i] + sorted[i + 1]) / 2);
+  }
+
+  return [...samples];
+};
+
+const resolveSubsectionBounds = (input: MomentReactionValidationInput): {
+  start: number;
+  end: number;
+} | null => {
+  const start = Number(input.offsetStartTime ?? 0);
+  if (!Number.isFinite(start) || start < 0) {
+    return null;
+  }
+
+  const finish = Number(input.reactionFinishTime);
+  const duration = Number(input.reactionDurationSeconds);
+  let end = Number.isFinite(finish) && finish > start ? finish : NaN;
+
+  if (!Number.isFinite(end) && Number.isFinite(duration) && duration > start) {
+    end = duration;
+  }
+
+  if (!Number.isFinite(end) || end <= start) {
+    return null;
+  }
+
+  return { start, end };
+};
+
+export function validateMomentReaction(
+  input: MomentReactionValidationInput
+): MomentReactionValidationResult {
+  const errors: string[] = [];
+  const momentTime = Number(input.momentOriginalTimeSeconds);
+
+  if (!Number.isFinite(momentTime) || momentTime < 0) {
+    return {
+      ok: false,
+      errors: ['Moment timing is missing or invalid.'],
+      subsectionDurationSeconds: null,
+      originalTimeRange: null
+    };
+  }
+
+  const bounds = resolveSubsectionBounds(input);
+  if (!bounds) {
+    return {
+      ok: false,
+      errors: [
+        'Set both a start and end time for this moment reaction subsection before publishing.'
+      ],
+      subsectionDurationSeconds: null,
+      originalTimeRange: null
+    };
+  }
+
+  const { start, end } = bounds;
+  const subsectionDurationSeconds = end - start;
+
+  if (subsectionDurationSeconds > MOMENT_REACTION_MAX_DURATION_SECONDS) {
+    errors.push(
+      `Moment reactions must be ${MOMENT_REACTION_MAX_DURATION_SECONDS} seconds or shorter (currently ${subsectionDurationSeconds.toFixed(1)}s).`
+    );
+  }
+
+  let stateTimeline = input.stateTimeline;
+  let playbackRateTimeline = input.playbackRateTimeline;
+  const timeOffset = Number(input.timeOffset ?? 0);
+
+  if (input.reactionData) {
+    const derived = deriveTimelines(input.reactionData);
+    stateTimeline = stateTimeline ?? derived.stateTimeline;
+    playbackRateTimeline = playbackRateTimeline ?? derived.playbackRateTimeline;
+  }
+
+  const sampleTimes = collectSubsectionSampleTimes(start, end, stateTimeline);
+  const originalTimes = sampleTimes.map((reactionTime) =>
+    getOriginalTimeAtReactionTime(reactionTime, {
+      stateTimeline,
+      playerConfigs: input.playerConfigs,
+      timeOffset,
+      playbackRateTimeline
+    })
+  );
+
+  const min = Math.min(...originalTimes);
+  const max = Math.max(...originalTimes);
+  const originalTimeRange = { min, max };
+
+  const reachedMoment =
+    momentTime >= min - MOMENT_ORIGINAL_TIME_TOLERANCE_SECONDS &&
+    momentTime <= max + MOMENT_ORIGINAL_TIME_TOLERANCE_SECONDS;
+
+  if (!reachedMoment) {
+    errors.push(
+      'Synchronization must reach the moment timing at least once during the selected subsection. Adjust start/end times or sync points, then try again.'
+    );
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    subsectionDurationSeconds,
+    originalTimeRange
+  };
+}
+
+export function validateMomentReactionFromReactionData(
+  reactionData: Record<string, unknown> | null | undefined,
+  momentOriginalTimeSeconds: number
+): MomentReactionValidationResult {
+  if (!reactionData || typeof reactionData !== 'object') {
+    return {
+      ok: false,
+      errors: ['Reaction data is unavailable.'],
+      subsectionDurationSeconds: null,
+      originalTimeRange: null
+    };
+  }
+
+  const { stateTimeline, playbackRateTimeline } = deriveTimelines(reactionData);
+
+  return validateMomentReaction({
+    momentOriginalTimeSeconds,
+    offsetStartTime: Number(reactionData.offsetStartTime ?? 0),
+    reactionFinishTime: Number(reactionData.reactionFinishTime),
+    reactionDurationSeconds: Number(
+      reactionData.duration ??
+        reactionData.youtube?.meta?.durationSeconds ??
+        reactionData.reactionDuration
+    ),
+    timeOffset: Number(reactionData.timeOffset ?? 0),
+    stateTimeline,
+    playbackRateTimeline,
+    reactionData
+  });
+}

--- a/src/lib/helpers/moments.js
+++ b/src/lib/helpers/moments.js
@@ -1,0 +1,8 @@
+export const slugifyMomentTitle = (value) =>
+  (value || '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);

--- a/src/lib/helpers/momentsFirestore.js
+++ b/src/lib/helpers/momentsFirestore.js
@@ -1,0 +1,188 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit,
+  startAfter,
+  updateDoc,
+  increment,
+  serverTimestamp
+} from 'firebase/firestore/lite';
+import { db, auth } from '$lib/constants/firebase';
+import { COLLECTION_MOMENTS, COLLECTION_REACTION_BINOMES } from '$lib/constants/firebase';
+import { MOMENT_SORT_OPTIONS } from '$lib/constants/moments';
+import { slugifyMomentTitle } from '$lib/helpers/moments';
+
+const createMomentsCollection = () => collection(db, COLLECTION_MOMENTS);
+const createReactionsCollection = () => collection(db, COLLECTION_REACTION_BINOMES);
+
+export const buildMomentPagePath = (momentId) => `/moments/${momentId}`;
+
+export const resolveMomentRouteId = (moment) => moment?.slug?.trim?.() || moment?.id || '';
+
+export const getMoment = async (momentId) => {
+  if (!momentId || !db) {
+    return null;
+  }
+  try {
+    const snap = await getDoc(doc(createMomentsCollection(), momentId));
+    if (!snap.exists()) {
+      return null;
+    }
+    return { id: snap.id, ...snap.data() };
+  } catch (error) {
+    console.error('Error loading moment:', error);
+    return null;
+  }
+};
+
+export const getMomentsByPage = async ({
+  lastDoc = null,
+  limitBy = 12,
+  sortBy = MOMENT_SORT_OPTIONS.NEWEST,
+  tag = ''
+} = {}) => {
+  let moments = [];
+  let lastVisible = null;
+
+  if (!db) {
+    return { moments, lastVisible };
+  }
+
+  try {
+    const momentsCollection = createMomentsCollection();
+    const constraints = [];
+
+    const normalizedTag = typeof tag === 'string' ? tag.trim() : '';
+    if (normalizedTag) {
+      constraints.push(where('tags', 'array-contains', normalizedTag));
+    }
+
+    if (sortBy === MOMENT_SORT_OPTIONS.MOST_REACTIONS || sortBy === MOMENT_SORT_OPTIONS.TRENDING) {
+      constraints.push(orderBy('reactionCount', 'desc'), orderBy('createdAt', 'desc'));
+    } else {
+      constraints.push(orderBy('createdAt', 'desc'));
+    }
+
+    let baseQuery = query(momentsCollection, ...constraints);
+    if (lastDoc) {
+      baseQuery = query(baseQuery, startAfter(lastDoc));
+    }
+    baseQuery = query(baseQuery, limit(limitBy));
+
+    const snapshot = await getDocs(baseQuery);
+    lastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null;
+    moments = snapshot.docs.map((entry) => ({
+      id: entry.id,
+      objectID: entry.id,
+      ...entry.data()
+    }));
+  } catch (error) {
+    console.error('Error loading moments page:', error);
+  }
+
+  return { moments, lastVisible };
+};
+
+export const getPublishedMomentReactions = async (momentId) => {
+  if (!momentId || !db) {
+    return [];
+  }
+
+  try {
+    const reactionsCollection = createReactionsCollection();
+    const queryRef = query(
+      reactionsCollection,
+      where('momentId', '==', momentId),
+      where('isMomentReaction', '==', true),
+      where('isPublished', '==', true),
+      orderBy('createdAt', 'desc')
+    );
+    const snapshot = await getDocs(queryRef);
+    return snapshot.docs.map((entry) => ({
+      id: entry.id,
+      data: entry.data()
+    }));
+  } catch (error) {
+    console.error('Error loading moment reactions:', error);
+    return [];
+  }
+};
+
+export const adjustMomentReactionCount = async (momentId, delta) => {
+  const numericDelta = Number(delta);
+  if (!momentId || !db || !Number.isFinite(numericDelta) || numericDelta === 0) {
+    return;
+  }
+
+  try {
+    const momentRef = doc(createMomentsCollection(), momentId);
+    await updateDoc(momentRef, {
+      reactionCount: increment(numericDelta),
+      updatedAt: serverTimestamp()
+    });
+  } catch (error) {
+    console.error('Failed to adjust moment reaction count:', error);
+  }
+};
+
+export const incrementMomentReactionCount = async (momentId) =>
+  adjustMomentReactionCount(momentId, 1);
+
+export const decrementMomentReactionCount = async (momentId) =>
+  adjustMomentReactionCount(momentId, -1);
+
+export const createMomentWithSlug = async (payload) => {
+  const { createMomentDocument } = await import('$lib/helpers/firebase');
+  const slug = slugifyMomentTitle(payload.title) || `moment-${Date.now()}`;
+  const momentId = await createMomentDocument({ ...payload, slug });
+  return { momentId, slug };
+};
+
+export const startMomentReactionDraft = async ({
+  momentId,
+  momentOriginalTimeSeconds,
+  originalVideoId,
+  originalVideoPlatform,
+  originalVideoTitle,
+  originalVideoAuthor,
+  originalVideoAuthorHandle,
+  originalVideoAuthorUrl,
+  originalVideoDescription,
+  originalVideoThumbnailUrl,
+  originalVideoThumbnailWidth,
+  originalVideoThumbnailHeight,
+  originalVideoProviderName,
+  originalVideoProviderUrl,
+  originalVideoUrl
+}) => {
+  const userId = auth?.currentUser?.uid;
+  if (!userId) {
+    throw new Error('Sign in to add a moment reaction.');
+  }
+
+  const { createMomentReactionDocument } = await import('$lib/helpers/firebase');
+  return createMomentReactionDocument({
+    momentId,
+    momentOriginalTimeSeconds,
+    originalVideoId,
+    originalVideoPlatform,
+    originalVideoTitle,
+    originalVideoAuthor,
+    originalVideoAuthorHandle,
+    originalVideoAuthorUrl,
+    originalVideoDescription,
+    originalVideoThumbnailUrl,
+    originalVideoThumbnailWidth,
+    originalVideoThumbnailHeight,
+    originalVideoProviderName,
+    originalVideoProviderUrl,
+    originalVideoUrl,
+    userId,
+    offsetStartTime: 0
+  });
+};

--- a/src/lib/helpers/momentsSearch.js
+++ b/src/lib/helpers/momentsSearch.js
@@ -1,0 +1,86 @@
+import { env } from '$env/dynamic/public';
+import { getSearchProvider, normalizeQuery } from '$lib/services/search';
+import { ALGOLIA_MOMENTS_INDEX } from '$lib/constants/algolia';
+import { getMomentsByPage } from '$lib/helpers/momentsFirestore';
+import { MOMENT_SORT_OPTIONS } from '$lib/constants/moments';
+
+export const hasMomentsAlgoliaIndex = () =>
+  Boolean(
+    env.PUBLIC_ALGOLIA_APP_ID &&
+      env.PUBLIC_ALGOLIA_SEARCH_API_KEY &&
+      ALGOLIA_MOMENTS_INDEX
+  );
+
+/**
+ * @param {Object} params
+ * @param {string} params.query
+ * @param {number} params.page
+ * @param {number} params.hitsPerPage
+ * @param {string} params.sortBy
+ * @param {string} params.tag
+ * @param {import('firebase/firestore').DocumentSnapshot | null} params.lastFirestoreDoc
+ */
+export async function searchMoments({
+  query = '',
+  page = 0,
+  hitsPerPage = 12,
+  sortBy = MOMENT_SORT_OPTIONS.NEWEST,
+  tag = '',
+  lastFirestoreDoc = null
+}) {
+  const normalizedQuery = normalizeQuery(query);
+
+  if (hasMomentsAlgoliaIndex()) {
+    const provider = getSearchProvider();
+    if (!provider?.isReady?.()) {
+      return { hits: [], nbHits: 0, page: 0, nbPages: 0, lastFirestoreDoc: null };
+    }
+
+    const result = await provider.search(normalizedQuery, {
+      index: ALGOLIA_MOMENTS_INDEX,
+      hitsPerPage,
+      page,
+      ...(tag ? { filters: `tags:"${tag.replace(/"/g, '')}"` } : {})
+    });
+
+    return {
+      hits: result.hits || [],
+      nbHits: result.nbHits || 0,
+      page: result.page || 0,
+      nbPages: result.nbPages || 0,
+      lastFirestoreDoc: null
+    };
+  }
+
+  const { moments, lastVisible } = await getMomentsByPage({
+    lastDoc: lastFirestoreDoc,
+    limitBy: hitsPerPage,
+    sortBy,
+    tag
+  });
+
+  let filtered = moments;
+  if (normalizedQuery) {
+    const needle = normalizedQuery.toLowerCase();
+    filtered = moments.filter((moment) => {
+      const haystack = [
+        moment.title,
+        moment.originalVideoTitle,
+        moment.originalVideoAuthor,
+        ...(Array.isArray(moment.tags) ? moment.tags : [])
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(needle);
+    });
+  }
+
+  return {
+    hits: filtered,
+    nbHits: filtered.length,
+    page: 0,
+    nbPages: filtered.length < hitsPerPage ? 1 : page + 2,
+    lastFirestoreDoc: lastVisible
+  };
+}

--- a/src/lib/helpers/twinPlayersEditorController.ts
+++ b/src/lib/helpers/twinPlayersEditorController.ts
@@ -20,6 +20,9 @@ import {
 } from '$lib/helpers/twinPlayersTimeline';
 import type { TwinPlayersState } from '$lib/helpers/twinPlayersStateController';
 import { downloadBasicVideoDetails, extractYouTubeVideoId } from '$lib/helpers/youtube';
+import { validateMomentReaction } from '$lib/helpers/momentReactionValidation';
+import { showToast } from '$lib/stores/toast';
+import { TOASTS } from '$lib/constants/toasts';
 
 type CreatePlayerConfigParams = {
   timeInReaction: number;
@@ -873,7 +876,41 @@ export function createTwinPlayersEditorController({
   };
 
   const setIsPublished = async () => {
+    const snapshot = getSnapshot();
+
+    if (snapshot.isMomentReaction) {
+      const momentTime = Number(snapshot.momentOriginalTimeSeconds);
+      const validation = validateMomentReaction({
+        momentOriginalTimeSeconds: momentTime,
+        offsetStartTime: snapshot.offsetStartTime,
+        reactionFinishTime: snapshot.reactionFinishTime,
+        reactionDurationSeconds: snapshot.reactionDuration,
+        timeOffset: snapshot.timeOffset,
+        stateTimeline: snapshot.stateTimeline,
+        playbackRateTimeline: snapshot.playbackRateTimeline
+      });
+
+      if (!validation.ok) {
+        const message =
+          validation.errors[0] ??
+          'This moment reaction does not meet publishing requirements yet.';
+        if (typeof window !== 'undefined') {
+          showToast(message, TOASTS.WARNING, 8000);
+        }
+        return;
+      }
+    }
+
+    const wasPublished = Boolean(snapshot.isPublished);
     await updateFirebaseDocument({ isPublished: true });
+
+    if (snapshot.isMomentReaction && snapshot.momentId && !wasPublished) {
+      const { incrementMomentReactionCount } = await import('$lib/helpers/momentsFirestore');
+      incrementMomentReactionCount(snapshot.momentId).catch((error: unknown) => {
+        console.error('Failed to increment moment reaction count', error);
+      });
+    }
+
     const reactionId =
       typeof window !== 'undefined' ? window.currentReactionDocumentId : undefined;
     if (reactionId) {
@@ -887,7 +924,16 @@ export function createTwinPlayersEditorController({
   };
 
   const setIsUnpublished = async () => {
+    const snapshot = getSnapshot();
+    const wasPublished = Boolean(snapshot.isPublished);
     await updateFirebaseDocument({ isPublished: false });
+
+    if (snapshot.isMomentReaction && snapshot.momentId && wasPublished) {
+      const { decrementMomentReactionCount } = await import('$lib/helpers/momentsFirestore');
+      decrementMomentReactionCount(snapshot.momentId).catch((error: unknown) => {
+        console.error('Failed to decrement moment reaction count', error);
+      });
+    }
     if (typeof location !== 'undefined') {
       location.reload();
     }

--- a/src/lib/helpers/twinPlayersInPlaceTransition.ts
+++ b/src/lib/helpers/twinPlayersInPlaceTransition.ts
@@ -109,6 +109,10 @@ export function buildTwinPlayersInPlaceStatePatch({
 
   return {
     isPublished: derived.isPublished,
+    momentId: derived.momentId,
+    isMomentReaction: derived.isMomentReaction,
+    momentOriginalTimeSeconds: derived.momentOriginalTimeSeconds,
+    momentFeedLoopEnabled: snapshotBefore.momentFeedLoopEnabled || derived.isMomentReaction,
     isReactionMissing: derived.isReactionMissing,
     reactorId: derived.resolvedReactorId,
     isUsersOwnVideo: derived.isUsersOwnVideo,

--- a/src/lib/helpers/twinPlayersOrchestrationController.ts
+++ b/src/lib/helpers/twinPlayersOrchestrationController.ts
@@ -417,6 +417,7 @@ export function createTwinPlayersOrchestrationController({
       reactionVideoDescription,
       nextPlayerOriginal: newPlayerOriginal,
       nextPlayerReaction: newPlayerReaction,
+      momentFeedLoopEnabled: getSnapshot().momentFeedLoopEnabled
     }));
 
     console.debug('[TwinPlayers] state reset after setUpVideos', {

--- a/src/lib/helpers/twinPlayersPlaybackSyncController.ts
+++ b/src/lib/helpers/twinPlayersPlaybackSyncController.ts
@@ -999,6 +999,17 @@ export function createTwinPlayersPlaybackSyncController({
       }
 
       if (reactionFinishTime > 0 && reactionCurrentTime > reactionFinishTime) {
+        if (snapshot.momentFeedLoopEnabled) {
+          const loopStart = Number.isFinite(snapshot.offsetStartTime)
+            ? Math.max(0, snapshot.offsetStartTime)
+            : 0;
+          goToSecondsInReactionVideo(loopStart);
+          if (typeof playerReaction?.playVideo === 'function') {
+            playerReaction.playVideo();
+          }
+          return;
+        }
+
         pauseOriginalVideo();
 
         if (!isPlaylistAutoPlay && !isQueueAutoPlay) {

--- a/src/lib/helpers/twinPlayersReactionData.ts
+++ b/src/lib/helpers/twinPlayersReactionData.ts
@@ -172,5 +172,10 @@ export function deriveTwinPlayersReactionData({
     canShowEditModeButton: resolvedReactorId === viewerUserId,
     isReactionMuteModeEnabled: Boolean(reactionData?.muteReactionWhileOriginalPlays),
     isPublished: reactionData?.isPublished,
+    momentId: typeof reactionData?.momentId === 'string' ? reactionData.momentId : undefined,
+    isMomentReaction: Boolean(reactionData?.isMomentReaction),
+    momentOriginalTimeSeconds: Number.isFinite(Number(reactionData?.momentOriginalTimeSeconds))
+      ? Number(reactionData.momentOriginalTimeSeconds)
+      : undefined,
   };
 }

--- a/src/lib/helpers/twinPlayersSetupState.ts
+++ b/src/lib/helpers/twinPlayersSetupState.ts
@@ -9,6 +9,7 @@ type BuildTwinPlayersSetupStatePatchParams = {
   reactionVideoDescription?: string;
   nextPlayerOriginal: any;
   nextPlayerReaction: any;
+  momentFeedLoopEnabled?: boolean;
 };
 
 export function buildTwinPlayersSetupStatePatch({
@@ -18,6 +19,7 @@ export function buildTwinPlayersSetupStatePatch({
   reactionVideoDescription,
   nextPlayerOriginal,
   nextPlayerReaction,
+  momentFeedLoopEnabled = false,
 }: BuildTwinPlayersSetupStatePatchParams) {
   return {
     isPublished: derived.isPublished,
@@ -69,6 +71,10 @@ export function buildTwinPlayersSetupStatePatch({
     isUserPaused: false,
     currentVolumeReactionVideo: derived.initialReactionVolume,
     reactionCurrentTime: derived.offsetStartTime || 0,
-    reactionDuration: typeof nextPlayerReaction?.getDuration === 'function' ? Number(nextPlayerReaction.getDuration()) || 0 : 0
+    reactionDuration: typeof nextPlayerReaction?.getDuration === 'function' ? Number(nextPlayerReaction.getDuration()) || 0 : 0,
+    momentId: derived.momentId,
+    isMomentReaction: derived.isMomentReaction,
+    momentOriginalTimeSeconds: derived.momentOriginalTimeSeconds,
+    momentFeedLoopEnabled: momentFeedLoopEnabled || derived.isMomentReaction
   };
 }

--- a/src/lib/helpers/twinPlayersStateController.ts
+++ b/src/lib/helpers/twinPlayersStateController.ts
@@ -79,6 +79,10 @@ export type TwinPlayersState = {
   seekMin: number;
   seekMax: number;
   originalVideoPlatform: 'youtube' | 'tiktok';
+  momentId?: string;
+  isMomentReaction: boolean;
+  momentOriginalTimeSeconds?: number;
+  momentFeedLoopEnabled: boolean;
 };
 
 type TwinPlayersContentState = Pick<
@@ -100,6 +104,9 @@ type TwinPlayersContentState = Pick<
   | 'youtubePlaylistId'
   | 'pageSlug'
   | 'originalVideoPlatform'
+  | 'momentId'
+  | 'isMomentReaction'
+  | 'momentOriginalTimeSeconds'
 >;
 
 type TwinPlayersCollectionState = Pick<
@@ -180,6 +187,7 @@ type CreateTwinPlayersStateControllerOptions = {
   isQueueAutoPlay: boolean;
   showCinematicBars: boolean;
   isFullscreen: boolean;
+  momentFeedLoopEnabled?: boolean;
 };
 
 const contentKeys = [
@@ -199,7 +207,11 @@ const contentKeys = [
   'reactorId',
   'youtubePlaylistId',
   'pageSlug',
-  'originalVideoPlatform'
+  'originalVideoPlatform',
+  'momentId',
+  'isMomentReaction',
+  'momentOriginalTimeSeconds',
+  'momentFeedLoopEnabled'
 ] as const;
 
 const collectionKeys = [
@@ -311,7 +323,8 @@ export function createTwinPlayersStateController({
   queueIndex,
   isQueueAutoPlay,
   showCinematicBars,
-  isFullscreen
+  isFullscreen,
+  momentFeedLoopEnabled = false
 }: CreateTwinPlayersStateControllerOptions) {
   const contentState = writable<TwinPlayersContentState>({
     isReactionMissing: false,
@@ -330,7 +343,11 @@ export function createTwinPlayersStateController({
     reactorId: undefined,
     youtubePlaylistId: undefined,
     pageSlug,
-    originalVideoPlatform: 'youtube'
+    originalVideoPlatform: 'youtube',
+    momentId: undefined,
+    isMomentReaction: false,
+    momentOriginalTimeSeconds: undefined,
+    momentFeedLoopEnabled
   });
 
   const collectionState = writable<TwinPlayersCollectionState>({

--- a/src/lib/server/firebaseAdmin.js
+++ b/src/lib/server/firebaseAdmin.js
@@ -338,3 +338,66 @@ export async function getPlaylistBySlug(slug) {
     return null;
   }
 }
+
+/**
+ * Fetch a moment document by id (or stored slug field matching route param).
+ */
+export async function getMomentByRouteId(routeId) {
+  const { COLLECTION_MOMENTS } = await import('$lib/constants/firebase');
+  const { adminDb } = await initializeFirebaseAdmin();
+  if (!adminDb || !routeId) {
+    return null;
+  }
+
+  try {
+    const directRef = adminDb.collection(COLLECTION_MOMENTS).doc(routeId);
+    const directSnap = await directRef.get();
+    if (directSnap.exists) {
+      return { id: directSnap.id, ...serializeFirestoreValue(directSnap.data()) };
+    }
+
+    const slugSnap = await adminDb
+      .collection(COLLECTION_MOMENTS)
+      .where('slug', '==', routeId)
+      .limit(1)
+      .get();
+
+    if (!slugSnap.empty) {
+      const doc = slugSnap.docs[0];
+      return { id: doc.id, ...serializeFirestoreValue(doc.data()) };
+    }
+  } catch (error) {
+    console.error('Failed to fetch moment by route id:', error);
+  }
+
+  return null;
+}
+
+/**
+ * Published moment reactions for feed ordering (newest first).
+ */
+export async function getPublishedMomentReactionsServer(momentId) {
+  const { COLLECTION_REACTION_BINOMES } = await import('$lib/constants/firebase');
+  const { adminDb } = await initializeFirebaseAdmin();
+  if (!adminDb || !momentId) {
+    return [];
+  }
+
+  try {
+    const snapshot = await adminDb
+      .collection(COLLECTION_REACTION_BINOMES)
+      .where('momentId', '==', momentId)
+      .where('isMomentReaction', '==', true)
+      .where('isPublished', '==', true)
+      .orderBy('createdAt', 'desc')
+      .get();
+
+    return snapshot.docs.map((doc) => ({
+      id: doc.id,
+      data: serializeFirestoreValue(doc.data())
+    }));
+  } catch (error) {
+    console.error('Failed to fetch moment reactions (server):', error);
+    return [];
+  }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,9 +21,12 @@
 
   $: isReactionRoute = $page.url.pathname?.startsWith("/reaction/");
   $: isPlaylistRoute = $page.url.pathname?.startsWith("/playlist/");
-  $: isPlaybackRoute = isReactionRoute || isPlaylistRoute;
+  $: isMomentFeedRoute = /^\/moments\/[^/]+$/.test($page.url.pathname || "");
+  $: isPlaybackRoute = isReactionRoute || isPlaylistRoute || isMomentFeedRoute;
   $: hideSpeedDial =
     isPlaybackRoute && ($reactionDial.isFullscreen || isMobileLandscapeTheater);
+  $: hideFooter = isMomentFeedRoute;
+  $: hideHeader = isMomentFeedRoute;
 
   onMount(() => {
     // Register service worker
@@ -70,7 +73,7 @@
 
     // Skip view transitions for reaction routes to prevent DOM instability during YouTube player initialization
     const toPath = navigation.to?.url?.pathname ?? '';
-    if (toPath.startsWith('/reaction/')) {
+    if (toPath.startsWith('/reaction/') || /^\/moments\/[^/]+$/.test(toPath)) {
       return;
     }
 
@@ -92,9 +95,11 @@
 
 <GoogleAnalytics />
 
-<header class="w-full safe-padding-x">
-  <TopNavigation />
-</header>
+{#if !hideHeader}
+  <header class="w-full safe-padding-x">
+    <TopNavigation />
+  </header>
+{/if}
 
 {#each currentToasts as toast (toast.id)}
   <Toast {toast} key={toast.id} />
@@ -118,7 +123,9 @@
   <SpeedDialNavigation />
 {/if}
 
-<Footer />
+{#if !hideFooter}
+  <Footer />
+{/if}
 
 <style>
   @import "../app.pcss";

--- a/src/routes/moments/+page.svelte
+++ b/src/routes/moments/+page.svelte
@@ -1,0 +1,240 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import { SearchOutline as SearchIcon, PlusOutline } from 'flowbite-svelte-icons';
+  import SEO from '$lib/components/SEO.svelte';
+  import MomentDiscoveryCard from '$lib/components/Moments/MomentDiscoveryCard.svelte';
+  import { searchMoments } from '$lib/helpers/momentsSearch';
+  import { DEFAULT_MOMENT_SORT, MOMENT_SORT_LABELS } from '$lib/constants/moments';
+
+  const HITS_PER_PAGE = 12;
+  const DEBOUNCE_DELAY = 600;
+
+  let query = '';
+  let sortBy = DEFAULT_MOMENT_SORT;
+  let tagFilter = '';
+  let loading = false;
+  let loadingMore = false;
+  let results = [];
+  let currentPage = 0;
+  let totalPages = 0;
+  let totalHits = 0;
+  let initialLoadDone = false;
+  let debounceTimer;
+  let sentinel;
+  let observer;
+  let lastFirestoreDoc = null;
+
+  $: hasMore = currentPage < totalPages - 1;
+  $: isSearchMode = query.trim().length > 0;
+
+  $: if (sentinel && !observer) {
+    observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !loading && !loadingMore) {
+          loadMore();
+        }
+      },
+      { rootMargin: '200px' }
+    );
+    observer.observe(sentinel);
+  }
+
+  onMount(async () => {
+    const url = $page.url.searchParams;
+    query = url.get('q') || '';
+    sortBy = url.get('sort') || DEFAULT_MOMENT_SORT;
+    tagFilter = url.get('tag') || '';
+    await loadResults(0);
+    initialLoadDone = true;
+  });
+
+  onDestroy(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    observer?.disconnect();
+  });
+
+  function syncUrl() {
+    const params = new URLSearchParams();
+    if (query.trim()) params.set('q', query.trim());
+    if (sortBy && sortBy !== DEFAULT_MOMENT_SORT) params.set('sort', sortBy);
+    if (tagFilter.trim()) params.set('tag', tagFilter.trim());
+    const suffix = params.toString();
+    goto(suffix ? `/moments?${suffix}` : '/moments', { replaceState: true, keepFocus: true });
+  }
+
+  async function loadResults(pageNum) {
+    if (pageNum === 0) {
+      loading = true;
+      lastFirestoreDoc = null;
+    } else {
+      loadingMore = true;
+    }
+
+    try {
+      const searchResult = await searchMoments({
+        query,
+        page: pageNum,
+        hitsPerPage: HITS_PER_PAGE,
+        sortBy,
+        tag: tagFilter,
+        lastFirestoreDoc: pageNum === 0 ? null : lastFirestoreDoc
+      });
+
+      if (pageNum === 0) {
+        results = searchResult.hits || [];
+      } else {
+        results = [...results, ...(searchResult.hits || [])];
+      }
+
+      currentPage = searchResult.page;
+      totalPages = searchResult.nbPages;
+      totalHits = searchResult.nbHits;
+      lastFirestoreDoc = searchResult.lastFirestoreDoc;
+    } catch (error) {
+      console.error('Moments search failed:', error);
+      if (pageNum === 0) results = [];
+    } finally {
+      loading = false;
+      loadingMore = false;
+    }
+  }
+
+  async function loadMore() {
+    if (hasMore && !loadingMore) {
+      await loadResults(currentPage + 1);
+    }
+  }
+
+  function applyFilters() {
+    syncUrl();
+    loadResults(0);
+  }
+
+  function handleInput() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(applyFilters, DEBOUNCE_DELAY);
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    if (debounceTimer) clearTimeout(debounceTimer);
+    applyFilters();
+  }
+
+  function handleSortChange(event) {
+    sortBy = event.currentTarget.value;
+    applyFilters();
+  }
+
+  function handleTagChange(event) {
+    tagFilter = event.currentTarget.value;
+    applyFilters();
+  }
+</script>
+
+<SEO
+  title="Moments Discovery"
+  description="Discover emotional moments in original videos and binge synchronized reactions."
+  canonical="/moments"
+  keywords="reaction moments, synchronized reactions, pure reactions moments"
+/>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-3xl font-semibold text-text-primary">Moments</h1>
+      <p class="mt-2 max-w-2xl text-base text-text-secondary">
+        Find a shared emotional beat in original content, then swipe through reactions synced to that exact moment.
+      </p>
+    </div>
+    <a
+      href="/moments/new"
+      class="inline-flex items-center justify-center gap-2 rounded-md bg-accent-primary px-md py-sm text-base font-medium text-background shadow-surface transition hover:bg-primary-600"
+    >
+      <PlusOutline class="h-5 w-5" aria-hidden="true" />
+      Create moment
+    </a>
+  </div>
+
+  <form class="mb-6 space-y-4" on:submit={handleSubmit}>
+    <div class="relative">
+      <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
+        <SearchIcon class="h-5 w-5 text-text-secondary" aria-hidden="true" />
+      </div>
+      <input
+        bind:value={query}
+        on:input={handleInput}
+        type="search"
+        class="block w-full rounded-2xl border border-border-strong/50 bg-surface/80 py-4 pl-12 pr-4 text-base text-text-primary placeholder:text-text-muted focus:border-focus focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-background"
+        placeholder="Search by moment title, original video, tags, or creator…"
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <label class="flex flex-col gap-1 text-sm text-text-secondary sm:flex-1">
+        <span>Sort</span>
+        <select
+          class="rounded-xl border border-border-strong/50 bg-surface/80 px-3 py-2 text-text-primary"
+          value={sortBy}
+          on:change={handleSortChange}
+        >
+          {#each Object.entries(MOMENT_SORT_LABELS) as [value, label]}
+            <option {value}>{label}</option>
+          {/each}
+        </select>
+      </label>
+      <label class="flex flex-col gap-1 text-sm text-text-secondary sm:flex-1">
+        <span>Tag filter</span>
+        <input
+          bind:value={tagFilter}
+          on:change={handleTagChange}
+          type="text"
+          class="rounded-xl border border-border-strong/50 bg-surface/80 px-3 py-2 text-text-primary"
+          placeholder="e.g. breakdown"
+        />
+      </label>
+    </div>
+  </form>
+
+  {#if loading}
+    <div class="flex justify-center py-24">
+      <div class="h-12 w-12 animate-spin rounded-full border-4 border-border-strong border-t-focus"></div>
+    </div>
+  {:else if results.length}
+    <p class="mb-4 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+      {#if isSearchMode}
+        {totalHits} {totalHits === 1 ? 'result' : 'results'}
+      {:else}
+        {totalHits || results.length} moments
+      {/if}
+    </p>
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {#each results as moment (moment.objectID || moment.id)}
+        <MomentDiscoveryCard {moment} />
+      {/each}
+    </div>
+    {#if loadingMore}
+      <div class="flex justify-center py-8">
+        <div class="h-8 w-8 animate-spin rounded-full border-4 border-border-strong border-t-focus"></div>
+      </div>
+    {/if}
+  {:else if initialLoadDone}
+    <div class="py-16 text-center text-text-secondary">
+      <p class="text-lg font-medium text-text-primary">No moments yet</p>
+      <p class="mt-2">Be the first to mark an emotional beat and invite reactions.</p>
+      <div class="mt-6">
+        <a
+          href="/moments/new"
+          class="inline-flex items-center justify-center rounded-md bg-accent-primary px-md py-sm text-base font-medium text-background"
+        >
+          Create a moment
+        </a>
+      </div>
+    </div>
+  {/if}
+
+  <div bind:this={sentinel} class="h-px w-full" aria-hidden="true"></div>
+</div>

--- a/src/routes/moments/[slug]/+page.js
+++ b/src/routes/moments/[slug]/+page.js
@@ -1,0 +1,8 @@
+/** @type {import('./$types').PageLoad} */
+export function load({ data, parent }) {
+  return parent().then((parentData) => ({
+    ...data,
+    userId: parentData?.userId ?? null,
+    displayName: parentData?.displayName ?? null
+  }));
+}

--- a/src/routes/moments/[slug]/+page.server.js
+++ b/src/routes/moments/[slug]/+page.server.js
@@ -1,0 +1,30 @@
+import { error } from '@sveltejs/kit';
+import {
+  getMomentByRouteId,
+  getPublishedMomentReactionsServer
+} from '$lib/server/firebaseAdmin';
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ params }) {
+  const routeId = params.slug;
+  if (!routeId) {
+    throw error(404, 'Moment not found');
+  }
+
+  const moment = await getMomentByRouteId(routeId);
+  if (!moment?.id) {
+    throw error(404, 'Moment not found');
+  }
+
+  const reactions = await getPublishedMomentReactionsServer(moment.id);
+  const reactionIds = reactions.map((entry) => entry.id);
+  const firstReactionId = reactionIds[0] || null;
+
+  return {
+    moment,
+    reactions,
+    reactionIds,
+    firstReactionId,
+    slug: routeId
+  };
+}

--- a/src/routes/moments/[slug]/+page.svelte
+++ b/src/routes/moments/[slug]/+page.svelte
@@ -1,0 +1,268 @@
+<script>
+  import { onDestroy, onMount, tick } from 'svelte';
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import SEO from '$lib/components/SEO.svelte';
+  import SubtleLoader from '$lib/components/design-system/SubtleLoader.svelte';
+  import ReactionStage from '$lib/components/reaction/ReactionStage.svelte';
+  import AttributionBlock from '$lib/components/reaction/AttributionBlock.svelte';
+  import MomentChrome from '$lib/components/Moments/MomentChrome.svelte';
+  import MomentPlayGate from '$lib/components/Moments/MomentPlayGate.svelte';
+  import { useTwinPlayers } from '$lib/composables/useTwinPlayers';
+  import { reactionDial } from '$lib/stores/reactionDial';
+  import { handlePrivateRoute } from '$lib/helpers/routing';
+  import { startMomentReactionDraft } from '$lib/helpers/momentsFirestore';
+  import { showToast } from '$lib/stores/toast';
+  import { TOASTS } from '$lib/constants/toasts';
+  import {
+    getYoutubeChannelClaim,
+    getYoutubeChannelVerification
+  } from '$lib/helpers/firebase';
+  import {
+    buildAttributionVerificationState
+  } from '$lib/helpers/reactionAttribution';
+
+  export let data;
+
+  $: moment = data?.moment;
+  $: momentId = moment?.id;
+  $: reactionIds = data?.reactionIds || [];
+  $: firstReactionId = data?.firstReactionId;
+
+  const initialReactionSlug = data?.firstReactionId || '';
+
+  let currentIndex = 0;
+  let playbackSessionStarted = false;
+  let showPlayGate = true;
+  let addReactionLoading = false;
+  let touchStartY = 0;
+  let isVerifiedCreator = false;
+  let overlayRef;
+
+  const { state, actions } = useTwinPlayers({
+    data: {
+      slug: initialReactionSlug,
+      userId: data?.userId,
+      displayName: data?.displayName
+    },
+    enableAutoPlay: false,
+    momentFeedLoopEnabled: true
+  });
+
+  $: overlayRef && actions.registerOverlayRef(overlayRef);
+  $: showPlayGate = !playbackSessionStarted && !$state.bothVideosStarted && !$state.isLoading;
+  $: reactionCount = Number(moment?.reactionCount) || reactionIds.length;
+
+  const resolveVerification = async () => {
+    const channelHandle = $state.reactionVideoAuthor;
+    if (!channelHandle) {
+      isVerifiedCreator = false;
+      return;
+    }
+    try {
+      const [claimRecord, verificationRecord] = await Promise.all([
+        getYoutubeChannelClaim(channelHandle),
+        getYoutubeChannelVerification(channelHandle)
+      ]);
+      isVerifiedCreator = buildAttributionVerificationState({
+        verificationRecord,
+        claimRecord,
+        reactorId: $state.reactorId,
+        channelHandle
+      }).isChannelVerified;
+    } catch (error) {
+      console.error('Failed to resolve channel verification', error);
+      isVerifiedCreator = false;
+    }
+  };
+
+  $: if (browser && $state.reactionVideoAuthor) {
+    resolveVerification();
+  }
+
+  const handlePlayGate = async () => {
+    playbackSessionStarted = true;
+    await actions.handlePlayStateChange(true);
+    if ($state.playerReaction?.playVideo) {
+      $state.playerReaction.playVideo();
+    }
+    if ($state.playerOriginal?.playVideo) {
+      $state.playerOriginal.playVideo();
+    }
+  };
+
+  const goToReactionIndex = async (nextIndex) => {
+    if (nextIndex < 0 || nextIndex >= reactionIds.length) return;
+    if (nextIndex === currentIndex) return;
+
+    currentIndex = nextIndex;
+    const nextId = reactionIds[nextIndex];
+    await actions.loadReactionInPlace(nextId, {
+      autoPlay: playbackSessionStarted
+    });
+  };
+
+  const handleTouchStart = (event) => {
+    touchStartY = event.changedTouches?.[0]?.clientY ?? 0;
+  };
+
+  const handleTouchEnd = (event) => {
+    const endY = event.changedTouches?.[0]?.clientY ?? touchStartY;
+    const delta = endY - touchStartY;
+    if (Math.abs(delta) < 56) return;
+    if (delta < 0) {
+      goToReactionIndex(currentIndex + 1);
+    } else {
+      goToReactionIndex(currentIndex - 1);
+    }
+  };
+
+  const handleWheel = (event) => {
+    if (Math.abs(event.deltaY) < 28) return;
+    event.preventDefault();
+    if (event.deltaY > 0) {
+      goToReactionIndex(currentIndex + 1);
+    } else {
+      goToReactionIndex(currentIndex - 1);
+    }
+  };
+
+  const handleAddReaction = async () => {
+    if (!momentId) return;
+    if (!data?.userId) {
+      handlePrivateRoute();
+      return;
+    }
+
+    addReactionLoading = true;
+    try {
+      const reactionDocumentId = await startMomentReactionDraft({
+        momentId,
+        momentOriginalTimeSeconds: Number(moment.momentTimeSeconds),
+        originalVideoId: moment.originalVideoId,
+        originalVideoPlatform: moment.originalVideoPlatform,
+        originalVideoTitle: moment.originalVideoTitle,
+        originalVideoAuthor: moment.originalVideoAuthor,
+        originalVideoUrl: moment.originalVideoUrl,
+        originalVideoThumbnailUrl: moment.originalVideoThumbnailUrl,
+        originalVideoThumbnailWidth: moment.originalVideoThumbnailWidth,
+        originalVideoThumbnailHeight: moment.originalVideoThumbnailHeight
+      });
+      await goto(`/edit-reaction/${reactionDocumentId}?momentId=${momentId}`);
+    } catch (error) {
+      console.error('Failed to start moment reaction draft', error);
+      showToast(error?.message || 'Unable to start a new reaction.', TOASTS.WARNING);
+    } finally {
+      addReactionLoading = false;
+    }
+  };
+
+  onMount(async () => {
+    if (!firstReactionId) return;
+    await tick();
+    actions.handleSlugChange(firstReactionId);
+  });
+
+  onDestroy(() => {
+    reactionDial.reset();
+  });
+</script>
+
+<SEO
+  title={moment?.title || 'Moment'}
+  description={moment?.originalVideoTitle
+    ? `Reactions synced to “${moment.title}” in ${moment.originalVideoTitle}`
+    : 'Binge synchronized reactions for this moment.'}
+  canonical="/moments/{data.slug}"
+  robots="index, follow"
+/>
+
+{#if !firstReactionId}
+  <div class="mx-auto max-w-lg px-4 py-24 text-center">
+    <h1 class="text-2xl font-semibold text-text-primary">{moment?.title || 'Moment'}</h1>
+    <p class="mt-3 text-text-secondary">No reactions yet. Be the first to sync one to this moment.</p>
+    <button
+      type="button"
+      class="mt-6 rounded-md bg-accent-primary px-4 py-2 text-background"
+      on:click={handleAddReaction}
+      disabled={addReactionLoading}
+    >
+      {addReactionLoading ? 'Starting…' : 'Add reaction'}
+    </button>
+  </div>
+{:else}
+  <div
+    class="moment-feed fixed inset-0 z-20 bg-black"
+    on:touchstart={handleTouchStart}
+    on:touchend={handleTouchEnd}
+    on:wheel|nonpassive={handleWheel}
+  >
+    {#if $state.isLoading}
+      <div class="absolute inset-0 z-40 flex items-center justify-center bg-background">
+        <SubtleLoader label="Preparing moment reaction" />
+      </div>
+    {/if}
+
+    <MomentChrome
+      {momentId}
+      momentTitle={moment?.title || 'Moment'}
+      {reactionCount}
+      onAddReaction={handleAddReaction}
+      {addReactionLoading}
+    />
+
+    <div class="relative h-full w-full" aria-hidden={$state.isLoading}>
+      <ReactionStage
+        isFullscreen={true}
+        isControlSurfaceVisible={$state.isControlSurfaceVisible}
+        isExitButtonExpanded={false}
+        showCinematicBars={false}
+        isReactionMissing={$state.isReactionMissing}
+        isUsersOwnVideo={$state.isUsersOwnVideo}
+        playerOriginal={$state.playerOriginal}
+        playerReaction={$state.playerReaction}
+        originalVideoPlatform={$state.originalVideoPlatform}
+        stickyControlsClass="opacity-100"
+        bothVideosStarted={$state.bothVideosStarted}
+        isPlaylist={false}
+        isPlaylistAutoPlay={false}
+        reactionCurrentTime={$state.reactionCurrentTime}
+        reactionDuration={$state.reactionDuration}
+        offsetStartTime={$state.offsetStartTime}
+        reactionFinishTime={$state.reactionFinishTime}
+        bind:overlayRef
+        on:playStateChanged={(event) => {
+          if (event.detail?.isPlaying) playbackSessionStarted = true;
+          actions.handlePlayStateChange(event.detail.isPlaying);
+        }}
+      />
+
+      <MomentPlayGate visible={showPlayGate} onPlay={handlePlayGate} />
+
+      <div class="pointer-events-none absolute inset-x-0 bottom-0 z-30 bg-gradient-to-t from-black/80 to-transparent px-4 pb-6 pt-16">
+        <div class="pointer-events-auto max-w-3xl">
+          <AttributionBlock
+            {isVerifiedCreator}
+            reactionVideoAuthor={$state.reactionVideoAuthor}
+            reactorDisplayName={$state.reactorDisplayName}
+            reactorId={$state.reactorId}
+            viewerId={data?.userId}
+          />
+          <p class="mt-3 text-xs text-white/60">
+            Swipe up or down for the next reaction · {currentIndex + 1} of {reactionIds.length}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  :global(body:has(.moment-feed)) {
+    overflow: hidden;
+  }
+
+  .moment-feed {
+    touch-action: pan-y;
+  }
+</style>

--- a/src/routes/moments/new/+page.svelte
+++ b/src/routes/moments/new/+page.svelte
@@ -1,0 +1,219 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { ArrowLeftOutline } from 'flowbite-svelte-icons';
+  import SEO from '$lib/components/SEO.svelte';
+  import CinematicButton from '$lib/components/design-system/CinematicButton.svelte';
+  import { auth } from '$lib/constants/firebase';
+  import { handlePrivateRoute } from '$lib/helpers/routing';
+  import { fetchOriginalVideoMetadata, originalVideoMetadataToFirestoreFields } from '$lib/helpers/originalVideo';
+  import { parseReactionSourceInput } from '$lib/helpers/reactionSequence';
+  import { createMomentWithSlug, buildMomentPagePath } from '$lib/helpers/momentsFirestore';
+  import { showToast } from '$lib/stores/toast';
+  import { TOASTS } from '$lib/constants/toasts';
+
+  let originalVideoInput = '';
+  let title = '';
+  let momentTimeSeconds = '0';
+  let tagsInput = '';
+  let isSubmitting = false;
+  let errorMessage = '';
+  let previewTitle = '';
+  let previewAuthor = '';
+
+  const clearError = () => {
+    if (errorMessage) errorMessage = '';
+  };
+
+  const readSource = () => {
+    const parsed = parseReactionSourceInput(originalVideoInput);
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error };
+    }
+    if (parsed.sourceItem?.type === 'youtube-playlist') {
+      return { ok: false, error: 'Use a single video link for a moment, not a playlist.' };
+    }
+    return { ok: true, source: parsed.sourceItem };
+  };
+
+  const previewOriginal = async () => {
+    clearError();
+    const parsed = readSource();
+    if (!parsed.ok) {
+      errorMessage = parsed.error;
+      return;
+    }
+
+    try {
+      const metadata = await fetchOriginalVideoMetadata({
+        platform: parsed.source.originalVideoPlatform,
+        videoId: parsed.source.originalVideoId,
+        videoUrl: parsed.source.originalVideoUrl
+      });
+      previewTitle = metadata.title || '';
+      previewAuthor = metadata.author || '';
+    } catch (error) {
+      console.error('Failed to preview original metadata', error);
+      errorMessage = 'Could not load that video. Check the URL and try again.';
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    clearError();
+
+    const user = auth?.currentUser;
+    if (!user?.uid) {
+      handlePrivateRoute();
+      return;
+    }
+
+    const parsed = readSource();
+    if (!parsed.ok) {
+      errorMessage = parsed.error;
+      return;
+    }
+    const source = parsed.source;
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      errorMessage = 'Give this moment a short, memorable title.';
+      return;
+    }
+
+    const anchorSeconds = Number(momentTimeSeconds);
+    if (!Number.isFinite(anchorSeconds) || anchorSeconds < 0) {
+      errorMessage = 'Enter the moment timing in seconds (0 or greater).';
+      return;
+    }
+
+    isSubmitting = true;
+    try {
+      const metadata = await fetchOriginalVideoMetadata({
+        platform: source.originalVideoPlatform,
+        videoId: source.originalVideoId,
+        videoUrl: source.originalVideoUrl
+      });
+      const firestoreFields = originalVideoMetadataToFirestoreFields(metadata);
+      const tags = tagsInput
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean);
+
+      const { momentId } = await createMomentWithSlug({
+        title: trimmedTitle,
+        originalVideoId: source.originalVideoId,
+        originalVideoPlatform: source.originalVideoPlatform,
+        originalVideoUrl: source.originalVideoUrl,
+        momentTimeSeconds: anchorSeconds,
+        tags,
+        creatorId: user.uid,
+        creatorDisplayName: user.displayName || '',
+        ...firestoreFields
+      });
+
+      showToast('Moment created.', TOASTS.SUCCESS);
+      await goto(buildMomentPagePath(momentId));
+    } catch (error) {
+      console.error('Failed to create moment', error);
+      errorMessage = error?.message || 'Something went wrong while creating the moment.';
+    } finally {
+      isSubmitting = false;
+    }
+  };
+
+  onMount(() => {
+    if (!auth?.currentUser) {
+      handlePrivateRoute();
+    }
+  });
+</script>
+
+<SEO
+  title="Create a Moment"
+  description="Mark an emotional beat in original content and invite synchronized reactions."
+  canonical="/moments/new"
+  robots="noindex, follow"
+/>
+
+<div class="mx-auto max-w-2xl px-4 py-10 sm:py-14">
+  <a
+    href="/moments"
+    class="inline-flex items-center gap-2 text-sm text-text-secondary transition hover:text-text-primary"
+  >
+    <ArrowLeftOutline class="h-4 w-4" aria-hidden="true" />
+    Back to moments
+  </a>
+
+  <h1 class="mt-6 text-3xl font-semibold text-text-primary">Create a moment</h1>
+  <p class="mt-2 text-base text-text-secondary">
+    A moment is a shared timestamp in original content—not a clip. Others can attach short synchronized reactions to it.
+  </p>
+
+  <form class="mt-8 space-y-6" on:submit={handleSubmit}>
+    <div class="space-y-2">
+      <label for="original-video" class="text-sm font-medium text-text-primary">Original video URL</label>
+      <input
+        id="original-video"
+        bind:value={originalVideoInput}
+        on:input={clearError}
+        on:blur={previewOriginal}
+        type="url"
+        class="w-full rounded-2xl border border-border-strong/50 bg-surface/80 px-4 py-3 text-text-primary"
+        placeholder="YouTube or TikTok link"
+        required
+      />
+      {#if previewTitle}
+        <p class="text-sm text-text-secondary">Loaded: {previewTitle}{previewAuthor ? ` · ${previewAuthor}` : ''}</p>
+      {/if}
+    </div>
+
+    <div class="space-y-2">
+      <label for="moment-title" class="text-sm font-medium text-text-primary">Moment title</label>
+      <input
+        id="moment-title"
+        bind:value={title}
+        on:input={clearError}
+        type="text"
+        maxlength="120"
+        class="w-full rounded-2xl border border-border-strong/50 bg-surface/80 px-4 py-3 text-text-primary"
+        placeholder="e.g. Will Ramos snorting scream"
+        required
+      />
+    </div>
+
+    <div class="space-y-2">
+      <label for="moment-time" class="text-sm font-medium text-text-primary">Moment time in original (seconds)</label>
+      <input
+        id="moment-time"
+        bind:value={momentTimeSeconds}
+        on:input={clearError}
+        type="number"
+        min="0"
+        step="0.1"
+        class="w-full rounded-2xl border border-border-strong/50 bg-surface/80 px-4 py-3 text-text-primary"
+        required
+      />
+      <p class="text-sm text-text-muted">The exact second in the original video this moment refers to.</p>
+    </div>
+
+    <div class="space-y-2">
+      <label for="moment-tags" class="text-sm font-medium text-text-primary">Tags (optional)</label>
+      <input
+        id="moment-tags"
+        bind:value={tagsInput}
+        type="text"
+        class="w-full rounded-2xl border border-border-strong/50 bg-surface/80 px-4 py-3 text-text-primary"
+        placeholder="breakdown, live, metal"
+      />
+    </div>
+
+    {#if errorMessage}
+      <p class="text-sm text-warning" role="alert">{errorMessage}</p>
+    {/if}
+
+    <CinematicButton type="submit" variant="primary" disabled={isSubmitting}>
+      {isSubmitting ? 'Creating…' : 'Create moment'}
+    </CinematicButton>
+  </form>
+</div>

--- a/tests/integration/moment-reaction-validation.test.js
+++ b/tests/integration/moment-reaction-validation.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MOMENT_REACTION_MAX_DURATION_SECONDS,
+  validateMomentReaction,
+  getOriginalTimeAtReactionTime
+} from '../../src/lib/helpers/momentReactionValidation.ts';
+
+describe('momentReactionValidation', () => {
+  it('rejects subsections longer than 60 seconds', () => {
+    const result = validateMomentReaction({
+      momentOriginalTimeSeconds: 120,
+      offsetStartTime: 0,
+      reactionFinishTime: 70,
+      timeOffset: 0,
+      stateTimeline: [{ t: 0, state: 1, targetTime: 100 }]
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes(String(MOMENT_REACTION_MAX_DURATION_SECONDS)))).toBe(
+      true
+    );
+  });
+
+  it('accepts when original playback range covers the moment time', () => {
+    const result = validateMomentReaction({
+      momentOriginalTimeSeconds: 50,
+      offsetStartTime: 10,
+      reactionFinishTime: 40,
+      timeOffset: 0,
+      stateTimeline: [
+        { t: 0, state: 1, targetTime: 40 },
+        { t: 10, state: 1, targetTime: 40 }
+      ],
+      playbackRateTimeline: [{ t: 0, rate: 1 }]
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects when original playback never reaches the moment time', () => {
+    const result = validateMomentReaction({
+      momentOriginalTimeSeconds: 200,
+      offsetStartTime: 0,
+      reactionFinishTime: 30,
+      timeOffset: 0,
+      stateTimeline: [{ t: 0, state: 1, targetTime: 10 }]
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('reach the moment timing'))).toBe(true);
+  });
+
+  it('maps reaction time to original time using sync configs', () => {
+    const originalAt20 = getOriginalTimeAtReactionTime(20, {
+      timeOffset: 5,
+      stateTimeline: [{ t: 0, state: 1, targetTime: 100 }],
+      playbackRateTimeline: [{ t: 0, rate: 1 }]
+    });
+
+    expect(originalAt20).toBeCloseTo(115, 1);
+  });
+});


### PR DESCRIPTION
Introduce a new Moments feature: adds moments collection, discovery UI, moment reactions, and client-side validation.

- Add docs/schema entry for `moments` and moment reaction fields; bump schema version to 1.8.
- Firestore rules: public read + owner create/update/delete for moments (moments, moments-local, moments-prod).
- Add Algolia indexing script for moments (scripts/algolia-index-moments.mjs) and package.json scripts; expose PUBLIC_ALGOLIA_MOMENTS_INDEX constant.
- New Svelte components: MomentChrome, MomentDiscoveryCard, MomentPlayGate and a TopNavigation link.
- Add routes for moments (listing, detail, new, and server/page loaders) and integration tests for moment reaction validation.
- New helpers: moments.js (slugify), momentsFirestore.js (CRUD, pagination, published reaction queries, reaction count adjustments), momentsSearch.js (Algolia fallback search), momentReactionValidation.ts (validation logic enforcing ≤60s subsection and synchronization requirements), plus createMoment/createMomentReaction in firebase helpers.
- Integrate moments into twin players: propagate moment fields in state, enable optional feed-looping behavior for moment reactions, validate before publish/unpublish and update moment reaction counts on publish/unpublish.

This change implements discovery, storage, search indexing, UI entrypoints, and strict client-side validation to ensure moment reactions meet publishing rules.