### PR TITLE
Generate sitemap including published reactions

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -91,6 +91,9 @@ function ensureAbsoluteUrl(value, baseUrl) {
 }
 
 function escapeXml(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
   return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -98,6 +101,134 @@ function escapeXml(value) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;');
 }
+
+async function getPublishedReactions(db) {
+  const collectionName = process.env.PUBLIC_FIREBASE_COLLECTION_REACTION_BINOMES || 'reactions';
+  console.log(`Querying collection: ${collectionName}`);
+  const reactionsSnapshot = await db.collection(collectionName).where('isPublished', '==', true).get();
+  if (reactionsSnapshot.empty) {
+    return [];
+  }
+  return reactionsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+}
+
+function groupReactionsByOriginalVideo(reactions) {
+  return reactions.reduce((acc, reaction) => {
+    const { originalVideoId } = reaction;
+    if (!acc[originalVideoId]) {
+      acc[originalVideoId] = [];
+    }
+    acc[originalVideoId].push(reaction);
+    return acc;
+  }, {});
+}
+
+async function generateSitemap() {
+  loadDotEnvIfPresent();
+  loadDotEnvIfPresent('.env.local');
+
+  const serviceAccount = resolveServiceAccount();
+  const baseUrl = ensureBaseUrl(process.env.PUBLIC_BASE_URL);
+
+  if (admin.apps.length === 0) {
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount)
+    });
+  }
+
+  const db = admin.firestore();
+
+  const staticRoutes = [
+    { path: '/', priority: '1.0', changefreq: 'daily' },
+    { path: '/privacy', priority: '0.5', changefreq: 'monthly' },
+    { path: '/terms', priority: '0.5', changefreq: 'monthly' },
+    { path: '/about', priority: '0.7', changefreq: 'monthly' },
+    { path: '/search', priority: '0.8', changefreq: 'weekly' }
+  ];
+
+  const allReactions = await getPublishedReactions(db);
+  const reactionsByOriginal = groupReactionsByOriginalVideo(allReactions);
+
+  const reactionUrls = [];
+  for (const originalVideoId in reactionsByOriginal) {
+    const group = reactionsByOriginal[originalVideoId];
+    if (group.length > 1) {
+      for (const reaction of group) {
+        const slug = reaction.slug || reaction.id;
+        const lastMod = reaction.updatedAt?.toDate()?.toISOString() || new Date().toISOString();
+        reactionUrls.push({
+          path: `/reaction/${slug}`,
+          priority: '0.9',
+          changefreq: 'weekly',
+          lastmod: lastMod,
+          image: ensureAbsoluteUrl(reaction.thumbnailUrl || DEFAULT_THUMBNAIL_PATH, baseUrl),
+          video: {
+            thumbnail_loc: ensureAbsoluteUrl(reaction.thumbnailUrl || DEFAULT_THUMBNAIL_PATH, baseUrl),
+            title: reaction.reactionVideoTitle,
+            description: reaction.description || `Reaction to ${reaction.originalVideoTitle}`,
+            player_loc: `${YOUTUBE_EMBED_BASE_URL}${reaction.reactionVideoId}`,
+            duration: reaction.duration,
+            publication_date: reaction.createdAt?.toDate()?.toISOString()
+          }
+        });
+      }
+    }
+  }
+
+  console.log(`Found ${allReactions.length} published reactions.`);
+  console.log(`Grouped into ${Object.keys(reactionsByOriginal).length} original videos.`);
+  console.log(`Adding ${reactionUrls.length} reaction pages to sitemap (from groups with >1 reaction).`);
+
+  const urls = [...staticRoutes, ...reactionUrls].slice(0, MAX_ENTRIES);
+
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+  xml += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n`;
+
+  for (const route of urls) {
+    const loc = ensureAbsoluteUrl(route.path, baseUrl);
+    if (!loc) continue;
+
+    xml += `  <url>\n`;
+    xml += `    <loc>${loc}</loc>\n`;
+    if (route.priority) xml += `    <priority>${route.priority}</priority>\n`;
+    if (route.changefreq) xml += `    <changefreq>${route.changefreq}</changefreq>\n`;
+    if (route.lastmod) xml += `    <lastmod>${route.lastmod}</lastmod>\n`;
+
+    if (route.image) {
+      xml += `    <image:image>\n`;
+      xml += `      <image:loc>${escapeXml(route.image)}</image:loc>\n`;
+      xml += `    </image:image>\n`;
+    }
+
+    if (route.video) {
+      xml += `    <video:video>\n`;
+      if (route.video.thumbnail_loc)
+        xml += `      <video:thumbnail_loc>${escapeXml(route.video.thumbnail_loc)}</video:thumbnail_loc>\n`;
+      if (route.video.title) xml += `      <video:title>${escapeXml(route.video.title)}</video:title>\n`;
+      if (route.video.description)
+        xml += `      <video:description>${escapeXml(route.video.description)}</video:description>\n`;
+      if (route.video.player_loc) xml += `      <video:player_loc>${escapeXml(route.video.player_loc)}</video:player_loc>\n`;
+      if (route.video.duration) xml += `      <video:duration>${route.video.duration}</video:duration>\n`;
+      if (route.video.publication_date)
+        xml += `      <video:publication_date>${route.video.publication_date}</video:publication_date>\n`;
+      xml += `    </video:video>\n`;
+    }
+
+    xml += `  </url>\n`;
+  }
+
+  xml += `</urlset>\n`;
+
+  fs.writeFileSync(OUTPUT_PATH, xml);
+  console.log(`Sitemap with ${urls.length} entries written to ${OUTPUT_PATH}`);
+}
+
+generateSitemap().catch((error) => {
+  console.error('Error generating sitemap:', error);
+  process.exit(1);
+});
 
 function wrapCdata(value) {
   const safe = value.replaceAll(']]>', ']]]]><![CDATA[>');

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -25,6 +25,38 @@ Ready to take the next step? Check out the link above for courses, lessons, pers
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/1x6mbIpqMYU1G4YI33sq</loc>
+    <lastmod>2026-04-23T18:28:50.934Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/n4v8AE5-Fn4/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[The Moment She Realizes Being a Cop’s Wife Isn’t Going To Help Her]]></video:title>
+      <video:description><![CDATA[Use code BOZEFDG to get 50% OFF your first Factor box plus free Daily Greens at https://bit.ly/47JJrkP!
+
+Officers question a woman during a DUI stop who keeps bringing up that her husband is a cop… but it’s not exactly helping her case.
+
+Original Video: https://www.youtube.com/watch?v=imhl2YXM4-k
+
+Bodycam channel: https://www.youtube.com/@bozebutshorter
+non-true crime channel & podcast: www.youtube.com/@BOZESBREAKROOM
+true crime blankets & merchandise: http://bozevstheworld.net
+
+live on mondays @ 4PM pst! http://twitch.tv/bozevstheworld | FULL 3+ HR STREAMS for subscribers AVAILABLE ON TWITCH TO SUBSCRIBERS. Subscriptions on Twitch are FREE if you connect your Amazon Prime account.
+
+I post regularly on INSTAGRAM - http://instagram.com/bigbossboze
+TikTok - http://tiktok.com/@bozevstheworld
+Twitch - http://twitch.tv/bozevstheworld
+Snapchat - https://www.snapchat.com/add/bozevstheworld
+Facebook - https://www.facebook.com/bigbossboze
+
+Team Business Email: bbossboze@gmail.com
+
+#bodycam #truecrime #reaction]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/n4v8AE5-Fn4</video:player_loc>
+      <video:duration>1758</video:duration>
+      <video:publication_date>2026-04-22T19:41:20.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/9RIvCmGaKJIyz22ytFMg</loc>
     <lastmod>2026-03-25T21:02:33.310Z</lastmod>
     <video:video>
@@ -92,6 +124,55 @@ Copyright Disclaimer Under Section 107 of the Copyright Act 1976, allowance is m
       <video:description><![CDATA[Sleep Token Yolculuğu - One]]></video:description>
       <video:player_loc>https://www.youtube.com/embed/dZAW3ckUAps</video:player_loc>
       <video:publication_date>2025-12-08T20:44:55.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/Cf2LeLInjOv0bbaWxtXK</loc>
+    <lastmod>2026-05-23T19:51:08.329Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/6Jx0PwzRWd8/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[I React to LORNA SHORE: TO THE HELLFIRE -  THE HEAVIEST REACTION YET]]></video:title>
+      <video:description><![CDATA[#LornaShore #ToTheHellfire #reaction 
+
+MERCH: https://www.bonfire.com/store/welcometothegarage/
+
+OUR SPONSOR: https://affinitysupplements.com/
+
+Want to send us fan mail?: 
+
+Rykerroad
+P.O. BOX 354
+Rittman, OH 44270
+
+Old Podcast Episodes:
+
+THE CAVE CAST
+https://www.youtube.com/c/TheCaveCast  (More Episodes Coming Soon)
+
+THE KYLEWRIGHT425 PODCAST
+https://youtube.com/playlist?list=PLL0ogZMO69H70RHhu26KKMqM5aNmmQiRa
+
+Gear:
+MICS: https://www.amazon.com/Shure-SM7B-Car...
+RODECASTER: https://www.amazon.com/s?k=rode+caste...
+TUBE LIGHTS: https://www.amazon.com/Photography-Pr...
+NEEWER LIGHTS: https://www.amazon.com/Neewer-Packs-D...
+
+PROGRAMS USED:
+Adobe Premiere Pro
+OBS Studio
+
+TIKTOK: @rykerroad
+PATREON: https://www.patreon.com/rykerroad
+Instagram: @emcfadden83
+
+Kyle's YouTube: https://www.youtube.com/kylewright425
+Kyle's Instagram: https://www.instagram.com/kylewright425
+
+*Copyright Disclaimer under Section 107 of the copyright act 1976, allowance is made for fair use for purposes such as criticism, comment, news reporting, scholarship, and research. Fair use is a use permitted by copyright statute that might otherwise be infringing. Non-profit, educational or personal use tips the balance in favor of fair use. No copyright infringement intended. All rights belong to respective owners*]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/6Jx0PwzRWd8</video:player_loc>
+      <video:duration>870</video:duration>
+      <video:publication_date>2022-09-01T19:33:21.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -203,6 +284,46 @@ Non-profit, educational, or personal use tips the balance in favor of fair use.
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/Dr2AhYJKvlj02vbI65lZ</loc>
+    <lastmod>2026-05-13T18:55:16.536Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/91k0r6JQ4ws/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Karmanjakah’s Diamond Morning Surprised Me… Did You Hear the Turkish Influence?]]></video:title>
+      <video:description><![CDATA[To experience the reaction together with the original album audio/video, use the PureReactions link below.
+🎧 https://purereactions.com/reaction/Dr2AhYJKvlj02vbI65lZ
+
+I went into this reaction with VERY high expectations based on @Karmanjakah's previous work… and somehow Diamond Morning still surprised me.
+
+This album feels fresh, emotional, progressive, unpredictable, and deeply atmospheric in a way very few bands manage today. Some moments genuinely caught me off guard.
+
+I also noticed influences and textures that reminded me of Turkish music and culture, which made the experience especially interesting and personal for me as someone of Turkish origin.
+
+In this reaction, I go through the full experience, discuss standout moments, and try to process what might be one of the most unique progressive releases I’ve heard in years.
+
+If you enjoyed the reaction, let me know which moments stood out to you most.
+
+⏱️ Timestamps
+
+00:00 Highlights
+00:13 Intro
+00:24 Dove
+05:50 Eyes Seeing Eyes
+09:50 Sun, Astray
+15:20 Moon, Astray
+24:27 Ruby
+32:13 Sapphire
+34:31 Thousand Horns
+36:04 Diamond Morning
+41:23 Diamond Art
+43:52 Diamond Train
+
+#Karmanjakah #DiamondMorning #ProgMetal #ProgressiveMetal #ReactionVideo]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/91k0r6JQ4ws</video:player_loc>
+      <video:duration>3158</video:duration>
+      <video:publication_date>2026-05-13T16:00:25.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/FDU6SCVNDnMFDieNasdb</loc>
     <lastmod>2026-01-25T15:24:45.583Z</lastmod>
     <video:video>
@@ -233,6 +354,23 @@ FRIDAYS: 12:00 PM EST
 #SleepToken]]></video:description>
       <video:player_loc>https://www.youtube.com/embed/6hymTo0gFxE</video:player_loc>
       <video:publication_date>2025-11-09T19:45:05.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/KREO9KmMSl8YRbGw5xqZ</loc>
+    <lastmod>2026-05-21T20:09:02.902Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/XUtIseGyBow/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V - FIRST REACTION]]></video:title>
+      <video:description><![CDATA[Our first time reacting to BLACKPINK - 'How You Like That' M/V
+We do not own the rights to the music or video.
+Original video: https://www.youtube.com/watch?v=ioNng23DkIM
+Thank you everyone for voting for this one - LOVE :)
+
+#blackpinkreaction #blackpink #howyoulikethat #blackpinkinyourarea]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/XUtIseGyBow</video:player_loc>
+      <video:duration>345</video:duration>
+      <video:publication_date>2025-04-22T04:41:26.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -336,6 +474,73 @@ Personal/Inquiries: Wendigoonmail@gmail.com]]></video:description>
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/anYfNXv7qG0WXOThdKs4</loc>
+    <lastmod>2026-05-20T19:33:20.313Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/ylOgThZU8dk/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V (INSANEEE!!!🔥😱)]]></video:title>
+      <video:description><![CDATA[💦Coldest Giveaway  👉 https://thecoldestwater.com/BROTHER-giveaway
+‼️Shop The Coldest Water  👉 https://thecoldestwater.com?ref=shop-BROTHER
+🛑Use Promo Code "BROTHER" to get 10% OFF your entire order.
+
+Viagem ao Brasil/Journey to Brazil🇧🇷✈️:
+: https://gogetfunding.com/?p=6300975
+
+
+LATEST VLOG (IT'LL MAKE YOU CRY😢)
+📺: https://youtu.be/ElCnlbV3QSE
+
+✅FOLLOW US:
+Instagram:
+: https://www.instagram.com/terryjr12/
+: https://www.instagram.com/kaniyiab/
+
+
+Tik tok⏰
+Terry's : https://vm.tiktok.com/bk2WjY/
+Kaniyia: https://vm.tiktok.com/bkHje8/
+
+
+Business Inquiries📩
+: terryjr12@yahoo.com]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/ylOgThZU8dk</video:player_loc>
+      <video:duration>402</video:duration>
+      <video:publication_date>2020-06-27T02:49:15.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/bHIkl56BQPUty8in5uKj</loc>
+    <lastmod>2026-05-19T20:32:39.256Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/7Rkbz0Ur1Ys/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[MODEL REACTS to BLACKPINK   'How You Like That' MV]]></video:title>
+      <video:description><![CDATA[Original Video - https://www.youtube.com/watch?v=ioNng23DkIM
+
+🔴Watch me LIVE🔴 https://www.twitch.tv/MODELMORG
+Join my Discord: https://discord.gg/3Ee4KrkXuZ
+
+• Follow my socials 🧃
+Main Youtube► https://www.youtube.com/@modelmorg
+Twitter► https://twitter.com/_modelmorg
+Instagram► https://www.instagram.com/_modelmorg
+TikTok► https://www.tiktok.com/@modelmorg
+
+• Edited by Gloup: 
+https://www.twitch.tv/gg_gloup
+
+Chapters
+0:00 - Intro
+0:29 - First Reaction
+3:29 - Afterthoughts
+7:54 - Outro
+
+#blackpink #kpop #rosé #jennie #jisoo #lisa]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/7Rkbz0Ur1Ys</video:player_loc>
+      <video:duration>522</video:duration>
+      <video:publication_date>2024-11-22T20:00:04.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/dBfiNLJMM8NHFP5aCjxi</loc>
     <lastmod>2026-01-25T15:24:48.782Z</lastmod>
     <video:video>
@@ -417,6 +622,88 @@ Kyle's Instagram: https://www.instagram.com/kylewright425
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/nvMFG2mkfETeHqE555yR</loc>
+    <lastmod>2026-05-18T20:39:42.966Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/p_f1wRll3BI/sddefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK (블랙핑크) - How You Like That MV REACTION by ABK CREW from Australia]]></video:title>
+      <video:description><![CDATA[Finally a new BLACKPINK comeback! 🤩 Let us know in the comments if you wanna see a cover from us 🙊
+
+Watch the original MV!
+https://youtu.be/ioNng23DkIM
+
+Reactors:
+Froi https://instagram.com/proyyylan/ 
+Nhi https://www.instagram.com/nhimofish/
+Jasmine https://instagram.com/pichi_nina/
+Saiya https://instagram.com/iam_saiya/
+Larissa https://instagram.com/larig141/
+Jen https://www.instagram.com/im_jennyn/
+Rose https://instagram.com/rosset_/
+Marred https://instagram.com/red_mapula/
+James https://instagram.com/jamavellanoza/
+Georgia https://instagram.com/931trbl/
+Caitlin https://instagram.com/caitlin_mary/
+
+Editing: Jen
+
+Use our code ‘ABKCREW’ for 10% off at Seoul Box https://seoulbox.co.uk
+
+Like us on Facebook: https://goo.gl/aRorVC
+Follow our Instagram: https://www.instagram.com/abk_crew/
+
+No copyright infringement intended.
+All music belongs to BLACKPINK and YG Entertainment.]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/p_f1wRll3BI</video:player_loc>
+      <video:duration>283</video:duration>
+      <video:publication_date>2020-06-26T13:30:04.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/trYOXmAvECltcvFjYqJp</loc>
+    <lastmod>2026-04-15T19:40:29.112Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/YWI3y4LpouE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[A Truly Incredible Display Of Free Will...]]></video:title>
+      <video:description><![CDATA[#anginedepoitrine #sarniezz #reaction 
+
+In this video I'm checking out the viral @AnginePoitrine and their song "Sarniezz" (Live on KEXP)
+
+Original Video: https://www.youtube.com/watch?v=t7OIc-DBRXM
+
+🤍Support On Patreon:
+https://www.patreon.com/DrewFortune
+
+🫂Join Discord Community:
+https://discord.gg/FP4kgrwyVc
+
+🎦Follow My Twitch:
+https://www.twitch.tv/drewfortune1
+
+📸Instagram:
+https://www.instagram.com/drewfortune?igsh=MWtmd3doNXhzMmFnYw%3D%3D&utm_source=qr
+
+🕹️Clips + Gaming Channel:
+https://youtube.com/@DrewFortuneClips?si=6rP-yrbH_ROI1WDD
+
+📩Business enquiries:
+DFBusinessEnquiries@gmail.com
+
+🥁Promote Your Band:
+https://www.drewfortune.com/services
+
+Timestamps:
+00:00 Intro
+00:56 Reaction
+05:43 Who Are Angine De Poitrine?
+
+Sub Count As Of Upload: 151,402]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/YWI3y4LpouE</video:player_loc>
+      <video:duration>612</video:duration>
+      <video:publication_date>2026-04-10T17:43:46.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/tywzKP0CzQbgbOxwI51I</loc>
     <lastmod>2026-04-08T20:26:53.146Z</lastmod>
     <video:video>
@@ -455,6 +742,75 @@ Just an attempt to make sense of the patterns — the attachment, the devotion, 
       <video:player_loc>https://www.youtube.com/embed/2FKBkSEdYQ8</video:player_loc>
       <video:duration>661</video:duration>
       <video:publication_date>2026-04-08T12:25:53.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/xvNsmEsRPanhJCi3Pnan</loc>
+    <lastmod>2026-04-20T11:54:13.206Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/RBu3spAIjxo/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Senator Fought the Release of This Bodycam | xQc Reacts]]></video:title>
+      <video:description><![CDATA[video: https://youtu.be/ZrXIF2lYKcE
+Subscribe to my other Youtube channels for even more content! 
+xQc Reacts: https://bit.ly/3FJk2Il
+xQc Gaming: https://bit.ly/3DGwBSF
+
+Streaming every day on Twitch and Kick!
+https://twitch.tv/xqc
+https://kick.com/xqc
+
+Stay Connected with xQc:
+►Twitter: https://twitter.com/xqc
+►Reddit: https://www.reddit.com/r/xqcow/
+►Discord: https://discord.gg/xqcow
+►Instagram: https://instagram.com/xqcow1/
+►Snapchat: xqcow1
+
+If you own copyrighted material in this video and would like it removed please contact ► xqcyoutube@defiancemgmt.com]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/RBu3spAIjxo</video:player_loc>
+      <video:duration>1282</video:duration>
+      <video:publication_date>2025-08-09T13:00:52.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/yaI037na1t6lVsUcD3KA</loc>
+    <lastmod>2026-05-18T20:13:23.878Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/-Fv-WkNCGWE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V | COMEBACK REACTION!!!]]></video:title>
+      <video:description><![CDATA[More Content On Patreon!!!
+https://www.patreon.com/BRISxGANG
+
+GET YOUR MERCH HERE!!!
+https://teespring.com/stores/bris-2019-collection
+
+2ND CHANNEL: more BRISXLIFE
+https://www.youtube.com/channel/UCY7u8gGMB9S1Xm4tan_WyAQ
+
+SUBSCRIBE!!!
+https://www.youtube.com/channel/UCFdAdgyV43x3OolPd8RQUig
+-------------------------------------------------------------------------------------------------------------
+Check out my reaction to BLACKPINK - 'How You Like That' M/V | COMEBACK REACTION!!! 
+
+ORIGINAL VIDEO: https://www.youtube.com/watch?v=ioNng23DkIM
+__________________________________________________________________
+HIT ME UP!
+
+Follow my INSTAGRAM!
+https://www.instagram.com/brisxlife/
+
+Follow my TWITTER!
+https://twitter.com/BRISxLIFE
+----------------------------------------­----------------------------------------­------------------------------
+BUSINESS ONLY: BRISxLIFE@gmail.com
+--------------------------------------------------------------------------------------------------------------
+
+IF YOU WANT TO MAIL SOMETHING TO ME:
+P.O BOX 5573
+Buena Park, CA 90622]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/-Fv-WkNCGWE</video:player_loc>
+      <video:duration>455</video:duration>
+      <video:publication_date>2020-06-26T09:39:59.000Z</video:publication_date>
     </video:video>
   </url>
 </urlset>


### PR DESCRIPTION
Add sitemap generation logic that queries published reaction documents from Firestore, groups reactions by originalVideoId, and adds reaction pages (with video and image metadata) for groups with more than one reaction. Also add a defensive check in escapeXml for non-string input and initialize Firebase admin using resolved service account and env vars. The script writes a sitemap XML (limited by MAX_ENTRIES) and logs progress. static/sitemap.xml was updated with generated reaction entries.