### PR TITLE
Refactor sitemap generator; add originals

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -4,10 +4,11 @@ import admin from 'firebase-admin';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 const OUTPUT_PATH = path.resolve(process.cwd(), 'static/sitemap.xml');
 const DEFAULT_THUMBNAIL_PATH = '/icon-512.png';
-const MAX_ENTRIES = 5000;
+const CANONICAL_BASE_URL = 'https://purereactions.com';
 const YOUTUBE_EMBED_BASE_URL = 'https://www.youtube.com/embed/';
 
 function loadDotEnvIfPresent(envPath = '.env') {
@@ -131,6 +132,11 @@ function pickLastmod(values) {
   return dates[0].toISOString();
 }
 
+function buildYoutubePlayerUrl(videoId) {
+  if (!videoId) return null;
+  return `${YOUTUBE_EMBED_BASE_URL}${encodeURIComponent(videoId)}`;
+}
+
 function pickReactionVideoId(data) {
   return pickText(
     data.reactionVideoId,
@@ -140,12 +146,7 @@ function pickReactionVideoId(data) {
   );
 }
 
-function buildYoutubePlayerUrl(videoId) {
-  if (!videoId) return null;
-  return `${YOUTUBE_EMBED_BASE_URL}${encodeURIComponent(videoId)}`;
-}
-
-function buildEntry({ docId, data, baseUrl }) {
+function buildReactionSitemapEntry({ docId, data, baseUrl }) {
   const slug = pickText(data.slug, docId);
   const loc = new URL(`/reaction/${slug}`, baseUrl).toString();
   const reactionVideoId = pickReactionVideoId(data);
@@ -193,13 +194,191 @@ function buildEntry({ docId, data, baseUrl }) {
   }
 
   lines.push('  </url>');
-  return lines.join('\n');
+  return {
+    docId,
+    slug,
+    loc,
+    lines: lines.join('\n')
+  };
+}
+
+function pickOriginalVideoThumbnail(data, baseUrl) {
+  return (
+    ensureAbsoluteUrl(data.originalVideoThumbnailUrl, baseUrl) ||
+    ensureAbsoluteUrl(data.originalYoutube?.meta?.thumbnail, baseUrl) ||
+    ensureAbsoluteUrl(data.originalTikTok?.meta?.thumbnail, baseUrl) ||
+    new URL(DEFAULT_THUMBNAIL_PATH, baseUrl).toString()
+  );
+}
+
+function pickOriginalVideoDurationSeconds(data) {
+  const durationSeconds =
+    data.originalYoutube?.meta?.durationSeconds ?? data.originalTikTok?.meta?.durationSeconds;
+
+  return Number.isFinite(durationSeconds) ? Math.round(durationSeconds) : null;
+}
+
+function pickBestReactionForMetadata(reactions) {
+  let bestReaction = null;
+  let bestTimestamp = -Infinity;
+
+  for (const reaction of reactions) {
+    const lastmod = pickLastmod([
+      reaction.data?.updatedAt,
+      reaction.data?.lastEnrichedAt,
+      reaction.data?.createdAt,
+      reaction.data?.youtube?.meta?.publishedAt
+    ]);
+    const timestamp = lastmod ? new Date(lastmod).valueOf() : -Infinity;
+
+    if (timestamp > bestTimestamp) {
+      bestTimestamp = timestamp;
+      bestReaction = reaction;
+    }
+  }
+
+  return bestReaction ?? reactions[0] ?? null;
+}
+
+function buildOriginalVideoEntry({ originalVideoId, originalVideoSlug, reactions, baseUrl }) {
+  if (!originalVideoId || !originalVideoSlug || reactions.length < 2) {
+    return null;
+  }
+
+  const representativeReaction = pickBestReactionForMetadata(reactions);
+  const data = representativeReaction?.data ?? {};
+  const slug = pickText(originalVideoSlug);
+
+  if (!slug) {
+    return null;
+  }
+
+  const loc = new URL(`/reactions/${encodeURIComponent(slug)}`, baseUrl).toString();
+  const playerLoc =
+    ensureAbsoluteUrl(data.originalVideoUrl, baseUrl) ||
+    buildYoutubePlayerUrl(data.originalVideoId || originalVideoId);
+
+  const title = pickText(
+    data.originalVideoTitle,
+    data.originalYoutube?.meta?.title,
+    data.originalTikTok?.meta?.title,
+    data.title,
+    slug
+  );
+  const description = pickText(
+    data.originalVideoDescription,
+    data.originalYoutube?.meta?.description,
+    data.originalTikTok?.meta?.description,
+    data.description,
+    'Reaction collection on Pure Reactions.'
+  );
+
+  const thumbnail = pickOriginalVideoThumbnail(data, baseUrl);
+  const lastmod = pickLastmod(
+    reactions.flatMap(({ data: reactionData }) => [
+      reactionData?.updatedAt,
+      reactionData?.lastEnrichedAt,
+      reactionData?.createdAt,
+      reactionData?.originalYoutube?.lastEnrichedAt,
+      reactionData?.originalTikTok?.lastEnrichedAt,
+      reactionData?.youtube?.meta?.publishedAt
+    ])
+  );
+  const durationSeconds = pickOriginalVideoDurationSeconds(data);
+  const publicationDate = pickLastmod([
+    data.originalYoutube?.meta?.publishedAt,
+    data.originalTikTok?.meta?.publishedAt,
+    data.youtube?.meta?.publishedAt
+  ]);
+
+  const lines = [];
+  lines.push('  <url>');
+  lines.push(`    <loc>${escapeXml(loc)}</loc>`);
+  if (lastmod) {
+    lines.push(`    <lastmod>${lastmod}</lastmod>`);
+  }
+
+  if (thumbnail && playerLoc) {
+    lines.push('    <video:video>');
+    lines.push(`      <video:thumbnail_loc>${escapeXml(thumbnail)}</video:thumbnail_loc>`);
+    lines.push(`      <video:title>${wrapCdata(title)}</video:title>`);
+    lines.push(`      <video:description>${wrapCdata(description)}</video:description>`);
+    lines.push(`      <video:player_loc>${escapeXml(playerLoc)}</video:player_loc>`);
+    if (durationSeconds && durationSeconds > 0) {
+      lines.push(`      <video:duration>${durationSeconds}</video:duration>`);
+    }
+    if (publicationDate) {
+      lines.push(`      <video:publication_date>${publicationDate}</video:publication_date>`);
+    }
+    lines.push('    </video:video>');
+  }
+
+  lines.push('  </url>');
+  return {
+    originalVideoId,
+    slug,
+    loc,
+    lines: lines.join('\n')
+  };
+}
+
+export function buildOriginalVideoSitemapEntries(reactionDocs, baseUrl) {
+  const groupedReactions = new Map();
+
+  for (const doc of reactionDocs) {
+    const data = doc?.data ?? {};
+    const originalVideoId = pickText(data.originalVideoId);
+    const originalVideoSlug = pickText(data.originalVideoSlug);
+
+    if (!originalVideoId || !originalVideoSlug) {
+      continue;
+    }
+
+    if (!groupedReactions.has(originalVideoId)) {
+      groupedReactions.set(originalVideoId, {
+        originalVideoId,
+        originalVideoSlug,
+        reactions: []
+      });
+    }
+
+    const group = groupedReactions.get(originalVideoId);
+    if (!group.originalVideoSlug && originalVideoSlug) {
+      group.originalVideoSlug = originalVideoSlug;
+    }
+
+    group.reactions.push(doc);
+  }
+
+  return [...groupedReactions.values()]
+    .filter(({ reactions }) => reactions.length >= 2)
+    .map((group) => buildOriginalVideoEntry({ ...group, baseUrl }))
+    .filter(Boolean)
+    .sort((a, b) => a.loc.localeCompare(b.loc));
+}
+
+export function buildReactionSitemapEntries(reactionDocs, baseUrl) {
+  return reactionDocs
+    .map((doc) => buildReactionSitemapEntry({ docId: doc.id, data: doc.data, baseUrl }))
+    .filter(Boolean)
+    .sort((a, b) => a.loc.localeCompare(b.loc));
+}
+
+async function fetchPublishedReactions(db, collection) {
+  let snapshot = await db.collection(collection).where('isPublished', '==', true).get();
+
+  if (snapshot.empty) {
+    snapshot = await db.collection(collection).where('published', '==', true).get();
+  }
+
+  return snapshot.docs.map((doc) => ({ id: doc.id, data: doc.data() }));
 }
 
 async function generate() {
   loadDotEnvIfPresent('.env');
 
-  const baseUrl = ensureBaseUrl(process.env.PUBLIC_BASE_URL);
+  ensureBaseUrl(process.env.PUBLIC_BASE_URL);
+  const baseUrl = CANONICAL_BASE_URL;
   const serviceAccount = resolveServiceAccount();
 
   if (!admin.apps.length) {
@@ -211,13 +390,13 @@ async function generate() {
 
   const db = admin.firestore();
   const collection = process.env.PUBLIC_FIREBASE_COLLECTION_REACTION_BINOMES || 'reactions';
-
-  let snapshot = await db.collection(collection).where('isPublished', '==', true).limit(MAX_ENTRIES).get();
-  if (snapshot.empty) {
-    snapshot = await db.collection(collection).where('published', '==', true).limit(MAX_ENTRIES).get();
-  }
-
-  const entries = snapshot.docs.map((doc) => buildEntry({ docId: doc.id, data: doc.data(), baseUrl }));
+  const reactions = await fetchPublishedReactions(db, collection);
+  const entries = [
+    ...buildReactionSitemapEntries(reactions, baseUrl),
+    ...buildOriginalVideoSitemapEntries(reactions, baseUrl)
+  ]
+    .sort((a, b) => a.loc.localeCompare(b.loc))
+    .map(({ lines }) => lines);
 
   const xml = [
     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -234,7 +413,13 @@ async function generate() {
   console.log(`[generate-sitemap] Wrote ${entries.length} entries to ${OUTPUT_PATH}`);
 }
 
-generate().catch((error) => {
-  console.error('[generate-sitemap] Failed to generate sitemap:', error);
-  process.exitCode = 1;
-});
+const isDirectExecution = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectExecution) {
+  generate().catch((error) => {
+    console.error('[generate-sitemap] Failed to generate sitemap:', error);
+    process.exitCode = 1;
+  });
+}
+
+export { fetchPublishedReactions, generate, pickBestReactionForMetadata, buildOriginalVideoEntry };

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -25,6 +25,38 @@ Ready to take the next step? Check out the link above for courses, lessons, pers
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/1x6mbIpqMYU1G4YI33sq</loc>
+    <lastmod>2026-04-23T18:28:50.934Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/n4v8AE5-Fn4/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[The Moment She Realizes Being a Cop’s Wife Isn’t Going To Help Her]]></video:title>
+      <video:description><![CDATA[Use code BOZEFDG to get 50% OFF your first Factor box plus free Daily Greens at https://bit.ly/47JJrkP!
+
+Officers question a woman during a DUI stop who keeps bringing up that her husband is a cop… but it’s not exactly helping her case.
+
+Original Video: https://www.youtube.com/watch?v=imhl2YXM4-k
+
+Bodycam channel: https://www.youtube.com/@bozebutshorter
+non-true crime channel & podcast: www.youtube.com/@BOZESBREAKROOM
+true crime blankets & merchandise: http://bozevstheworld.net
+
+live on mondays @ 4PM pst! http://twitch.tv/bozevstheworld | FULL 3+ HR STREAMS for subscribers AVAILABLE ON TWITCH TO SUBSCRIBERS. Subscriptions on Twitch are FREE if you connect your Amazon Prime account.
+
+I post regularly on INSTAGRAM - http://instagram.com/bigbossboze
+TikTok - http://tiktok.com/@bozevstheworld
+Twitch - http://twitch.tv/bozevstheworld
+Snapchat - https://www.snapchat.com/add/bozevstheworld
+Facebook - https://www.facebook.com/bigbossboze
+
+Team Business Email: bbossboze@gmail.com
+
+#bodycam #truecrime #reaction]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/n4v8AE5-Fn4</video:player_loc>
+      <video:duration>1758</video:duration>
+      <video:publication_date>2026-04-22T19:41:20.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/9RIvCmGaKJIyz22ytFMg</loc>
     <lastmod>2026-03-25T21:02:33.310Z</lastmod>
     <video:video>
@@ -46,6 +78,84 @@ This Muse Be With You reaction and review is genuinely my first time hearing thi
       <video:player_loc>https://www.youtube.com/embed/lNGtveT3p10</video:player_loc>
       <video:duration>317</video:duration>
       <video:publication_date>2026-03-20T16:30:31.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/anYfNXv7qG0WXOThdKs4</loc>
+    <lastmod>2026-06-20T19:24:47.817Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/ylOgThZU8dk/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V (INSANEEE!!!🔥😱)]]></video:title>
+      <video:description><![CDATA[💦Coldest Giveaway  👉 https://thecoldestwater.com/BROTHER-giveaway
+‼️Shop The Coldest Water  👉 https://thecoldestwater.com?ref=shop-BROTHER
+🛑Use Promo Code "BROTHER" to get 10% OFF your entire order.
+
+Viagem ao Brasil/Journey to Brazil🇧🇷✈️:
+: https://gogetfunding.com/?p=6300975
+
+
+LATEST VLOG (IT'LL MAKE YOU CRY😢)
+📺: https://youtu.be/ElCnlbV3QSE
+
+✅FOLLOW US:
+Instagram:
+: https://www.instagram.com/terryjr12/
+: https://www.instagram.com/kaniyiab/
+
+
+Tik tok⏰
+Terry's : https://vm.tiktok.com/bk2WjY/
+Kaniyia: https://vm.tiktok.com/bkHje8/
+
+
+Business Inquiries📩
+: terryjr12@yahoo.com]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/ylOgThZU8dk</video:player_loc>
+      <video:duration>402</video:duration>
+      <video:publication_date>2020-06-27T02:49:15.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/BbsAWJGI6BeB6LmFi3Da</loc>
+    <lastmod>2026-01-25T15:24:44.749Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/dZAW3ckUAps/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Sleep Token Yolculuğu - One]]></video:title>
+      <video:description><![CDATA[Sleep Token Yolculuğu - One]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/dZAW3ckUAps</video:player_loc>
+      <video:publication_date>2025-12-08T20:44:55.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/bHIkl56BQPUty8in5uKj</loc>
+    <lastmod>2026-06-20T19:32:10.700Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/7Rkbz0Ur1Ys/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[MODEL REACTS to BLACKPINK   'How You Like That' MV]]></video:title>
+      <video:description><![CDATA[Original Video - https://www.youtube.com/watch?v=ioNng23DkIM
+
+🔴Watch me LIVE🔴 https://www.twitch.tv/MODELMORG
+Join my Discord: https://discord.gg/3Ee4KrkXuZ
+
+• Follow my socials 🧃
+Main Youtube► https://www.youtube.com/@modelmorg
+Twitter► https://twitter.com/_modelmorg
+Instagram► https://www.instagram.com/_modelmorg
+TikTok► https://www.tiktok.com/@modelmorg
+
+• Edited by Gloup: 
+https://www.twitch.tv/gg_gloup
+
+Chapters
+0:00 - Intro
+0:29 - First Reaction
+3:29 - Afterthoughts
+7:54 - Outro
+
+#blackpink #kpop #rosé #jennie #jisoo #lisa]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/7Rkbz0Ur1Ys</video:player_loc>
+      <video:duration>522</video:duration>
+      <video:publication_date>2024-11-22T20:00:04.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -84,14 +194,52 @@ Copyright Disclaimer Under Section 107 of the Copyright Act 1976, allowance is m
     </video:video>
   </url>
   <url>
-    <loc>https://purereactions.com/reaction/BbsAWJGI6BeB6LmFi3Da</loc>
-    <lastmod>2026-01-25T15:24:44.749Z</lastmod>
+    <loc>https://purereactions.com/reaction/Cf2LeLInjOv0bbaWxtXK</loc>
+    <lastmod>2026-05-23T19:51:08.329Z</lastmod>
     <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/dZAW3ckUAps/maxresdefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[Sleep Token Yolculuğu - One]]></video:title>
-      <video:description><![CDATA[Sleep Token Yolculuğu - One]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/dZAW3ckUAps</video:player_loc>
-      <video:publication_date>2025-12-08T20:44:55.000Z</video:publication_date>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/6Jx0PwzRWd8/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[I React to LORNA SHORE: TO THE HELLFIRE -  THE HEAVIEST REACTION YET]]></video:title>
+      <video:description><![CDATA[#LornaShore #ToTheHellfire #reaction 
+
+MERCH: https://www.bonfire.com/store/welcometothegarage/
+
+OUR SPONSOR: https://affinitysupplements.com/
+
+Want to send us fan mail?: 
+
+Rykerroad
+P.O. BOX 354
+Rittman, OH 44270
+
+Old Podcast Episodes:
+
+THE CAVE CAST
+https://www.youtube.com/c/TheCaveCast  (More Episodes Coming Soon)
+
+THE KYLEWRIGHT425 PODCAST
+https://youtube.com/playlist?list=PLL0ogZMO69H70RHhu26KKMqM5aNmmQiRa
+
+Gear:
+MICS: https://www.amazon.com/Shure-SM7B-Car...
+RODECASTER: https://www.amazon.com/s?k=rode+caste...
+TUBE LIGHTS: https://www.amazon.com/Photography-Pr...
+NEEWER LIGHTS: https://www.amazon.com/Neewer-Packs-D...
+
+PROGRAMS USED:
+Adobe Premiere Pro
+OBS Studio
+
+TIKTOK: @rykerroad
+PATREON: https://www.patreon.com/rykerroad
+Instagram: @emcfadden83
+
+Kyle's YouTube: https://www.youtube.com/kylewright425
+Kyle's Instagram: https://www.instagram.com/kylewright425
+
+*Copyright Disclaimer under Section 107 of the copyright act 1976, allowance is made for fair use for purposes such as criticism, comment, news reporting, scholarship, and research. Fair use is a use permitted by copyright statute that might otherwise be infringing. Non-profit, educational or personal use tips the balance in favor of fair use. No copyright infringement intended. All rights belong to respective owners*]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/6Jx0PwzRWd8</video:player_loc>
+      <video:duration>870</video:duration>
+      <video:publication_date>2022-09-01T19:33:21.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -151,6 +299,22 @@ reactbot: https://jacksfilmscouncil-shop.fourthwall.com/products/reactbot-exe
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/dBfiNLJMM8NHFP5aCjxi</loc>
+    <lastmod>2026-01-25T15:24:48.782Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/OU8mJIOTr9U/sddefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Don't Be Fooled By This $20,000 Robot]]></video:title>
+      <video:description><![CDATA[Marques Brownlee https://www.youtube.com/watch?v=j31dmodZ-5c
+Starforge PC https://starforgepc.com/moist-yt
+Get Goof Juice and use code MOIST https://gamersupps.gg/moist
+Our soap https://usecheeky.com/#starter-pack-offer
+Gaming channel https://www.youtube.com/@MoistCr1TiKaLGamingOfficial
+This is the greatest neo robot of All Time]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/OU8mJIOTr9U</video:player_loc>
+      <video:publication_date>2025-10-31T01:45:02.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/DnSr31zHA3GcKGPKKuOv</loc>
     <lastmod>2026-01-25T15:24:45.304Z</lastmod>
     <video:video>
@@ -203,6 +367,46 @@ Non-profit, educational, or personal use tips the balance in favor of fair use.
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/Dr2AhYJKvlj02vbI65lZ</loc>
+    <lastmod>2026-06-15T15:41:19.396Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/91k0r6JQ4ws/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Karmanjakah’s Diamond Morning Surprised Me… Did You Hear the Turkish Influence?]]></video:title>
+      <video:description><![CDATA[To experience the reaction together with the original album audio/video, use the PureReactions link below.
+🎧 https://purereactions.com/reaction/Dr2AhYJKvlj02vbI65lZ
+
+I went into this reaction with VERY high expectations based on @Karmanjakah's previous work… and somehow Diamond Morning still surprised me.
+
+This album feels fresh, emotional, progressive, unpredictable, and deeply atmospheric in a way very few bands manage today. Some moments genuinely caught me off guard.
+
+I also noticed influences and textures that reminded me of Turkish music and culture, which made the experience especially interesting and personal for me as someone of Turkish origin.
+
+In this reaction, I go through the full experience, discuss standout moments, and try to process what might be one of the most unique progressive releases I’ve heard in years.
+
+If you enjoyed the reaction, let me know which moments stood out to you most.
+
+⏱️ Timestamps
+
+00:00 Highlights
+00:13 Intro
+00:24 Dove
+05:50 Eyes Seeing Eyes
+09:50 Sun, Astray
+15:20 Moon, Astray
+24:27 Ruby
+32:13 Sapphire
+34:31 Thousand Horns
+36:04 Diamond Morning
+41:23 Diamond Art
+43:52 Diamond Train
+
+#Karmanjakah #DiamondMorning #ProgMetal #ProgressiveMetal #ReactionVideo]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/91k0r6JQ4ws</video:player_loc>
+      <video:duration>3158</video:duration>
+      <video:publication_date>2026-05-13T16:00:25.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/FDU6SCVNDnMFDieNasdb</loc>
     <lastmod>2026-01-25T15:24:45.583Z</lastmod>
     <video:video>
@@ -236,6 +440,60 @@ FRIDAYS: 12:00 PM EST
     </video:video>
   </url>
   <url>
+    <loc>https://purereactions.com/reaction/fYxd94BCAZE1PTHOS5mi</loc>
+    <lastmod>2026-03-06T19:59:29.981Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/ZbHRP5nfio0/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[THIS WAS EPIC | PRETTY WHEN YOU BREAK | EKOH & CATCH YOUR BREATH]]></video:title>
+      <video:description><![CDATA[#ekoh #catchyourbreath #reaction #hiphophead #metalheadreacts #fyp 
+GET YOUR RIZZ HERE AND USE THE CODE (RR 15) AT CHECKOUT: https://rizzhydration.com/order-page?am_id=RykerRoad
+
+Check out our PODCAST : https://www.youtube.com/@TheCaveCast
+
+LISTEN TO THE CAVE CAST ON SPOTIFY AND MORE: https://rss.com/podcasts/the-cave-cast
+
+NEED A PC? CHECK THIS OUT: https://romanhillspc.com/
+
+EMAIL: rykerroad83@gmail.com
+
+TWITCH: https://www.twitch.tv/rykerroad83
+
+DISCORD: https://discord.gg/JksJFxCzdN
+
+FACEBOOK FAN PAGE: https://www.facebook.com/groups/1351062802203779/
+
+MERCH: https://rykerroad-2024.itemorder.com/
+
+Want to send us fan mail?: 
+
+Rykerroad
+P.O. BOX 354
+Rittman, OH 44270
+
+Gear:
+MICS: https://www.amazon.com/Shure-SM7B-Car...
+RODECASTER: https://www.amazon.com/s?k=rode+caste...
+TUBE LIGHTS: https://www.amazon.com/Photography-Pr...
+NEEWER LIGHTS: https://www.amazon.com/Neewer-Packs-D...
+
+PROGRAMS USED:
+Adobe Premiere Pro
+OBS Studio
+
+TIKTOK: @rykerroad
+PATREON: https://www.patreon.com/rykerroad
+Instagram: @rykerroad
+
+Kyle's YouTube: https://www.youtube.com/kylewright425
+Kyle's Instagram: https://www.instagram.com/kylewright425
+
+*Copyright Disclaimer under Section 107 of the copyright act 1976, allowance is made for fair use for purposes such as criticism, comment, news reporting, scholarship, and research. Fair use is a use permitted by copyright statute that might otherwise be infringing. Non-profit, educational or personal use tips the balance in favor of fair use. No copyright infringement intended. All rights belong to respective owners*]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/daLbKVAETu4</video:player_loc>
+      <video:duration>1335</video:duration>
+      <video:publication_date>2026-03-06T02:12:10.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
     <loc>https://purereactions.com/reaction/MFVSQreRxOerCeRWvrBw</loc>
     <lastmod>2026-01-25T15:24:46.523Z</lastmod>
     <video:video>
@@ -244,6 +502,55 @@ FRIDAYS: 12:00 PM EST
       <video:description><![CDATA[Watch alongside original video here : https://purereactions.com/reaction/MFVSQreRxOerCeRWvrBw]]></video:description>
       <video:player_loc>https://www.youtube.com/embed/gcfyvwQbPRs</video:player_loc>
       <video:publication_date>2024-04-23T12:55:16.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/nQpdziRL4J8Qmh4QJdKX</loc>
+    <lastmod>2026-01-25T15:24:49.135Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/onF-OAlDu48/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Bilmuri - Blindsided - Pure Reactions]]></video:title>
+      <video:description><![CDATA[Watch the reaction alongside the original here: https://purereactions.com/reaction/nQpdziRL4J8Qmh4QJdKX]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/onF-OAlDu48</video:player_loc>
+      <video:publication_date>2024-04-23T12:55:31.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/nvMFG2mkfETeHqE555yR</loc>
+    <lastmod>2026-06-20T19:24:39.481Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/p_f1wRll3BI/sddefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK (블랙핑크) - How You Like That MV REACTION by ABK CREW from Australia]]></video:title>
+      <video:description><![CDATA[Finally a new BLACKPINK comeback! 🤩 Let us know in the comments if you wanna see a cover from us 🙊
+
+Watch the original MV!
+https://youtu.be/ioNng23DkIM
+
+Reactors:
+Froi https://instagram.com/proyyylan/ 
+Nhi https://www.instagram.com/nhimofish/
+Jasmine https://instagram.com/pichi_nina/
+Saiya https://instagram.com/iam_saiya/
+Larissa https://instagram.com/larig141/
+Jen https://www.instagram.com/im_jennyn/
+Rose https://instagram.com/rosset_/
+Marred https://instagram.com/red_mapula/
+James https://instagram.com/jamavellanoza/
+Georgia https://instagram.com/931trbl/
+Caitlin https://instagram.com/caitlin_mary/
+
+Editing: Jen
+
+Use our code ‘ABKCREW’ for 10% off at Seoul Box https://seoulbox.co.uk
+
+Like us on Facebook: https://goo.gl/aRorVC
+Follow our Instagram: https://www.instagram.com/abk_crew/
+
+No copyright infringement intended.
+All music belongs to BLACKPINK and YG Entertainment.]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/p_f1wRll3BI</video:player_loc>
+      <video:duration>283</video:duration>
+      <video:publication_date>2020-06-26T13:30:04.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -314,106 +621,47 @@ Personal/Inquiries: Wendigoonmail@gmail.com]]></video:description>
     </video:video>
   </url>
   <url>
-    <loc>https://purereactions.com/reaction/XbsHexRoxYNDqQk5Cmw9</loc>
-    <lastmod>2026-01-25T15:24:47.955Z</lastmod>
+    <loc>https://purereactions.com/reaction/trYOXmAvECltcvFjYqJp</loc>
+    <lastmod>2026-04-15T19:40:29.112Z</lastmod>
     <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/n1UszpQaxwI/maxresdefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[Pure Reactions - @2SICH - Let’s vibe y’all]]></video:title>
-      <video:description><![CDATA[Watch alongside the original here: https://purereactions.com/reaction/XbsHexRoxYNDqQk5Cmw9]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/n1UszpQaxwI</video:player_loc>
-      <video:publication_date>2024-04-30T20:42:07.000Z</video:publication_date>
-    </video:video>
-  </url>
-  <url>
-    <loc>https://purereactions.com/reaction/ZZoCAht2hzYl7gjt5kI7</loc>
-    <lastmod>2026-01-25T15:24:48.334Z</lastmod>
-    <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/nTNP_ef4O5w/maxresdefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[Pure Reactions - Worst Doctor Ever - @penguinz0]]></video:title>
-      <video:description><![CDATA[Watch the full reaction along with the original video side-by-side on my platform Pure Reactions (completely free) https://purereactions.com/reaction/ZZoCAht2hzYl7gjt5kI7/]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/nTNP_ef4O5w</video:player_loc>
-      <video:publication_date>2024-06-14T19:47:46.000Z</video:publication_date>
-    </video:video>
-  </url>
-  <url>
-    <loc>https://purereactions.com/reaction/dBfiNLJMM8NHFP5aCjxi</loc>
-    <lastmod>2026-01-25T15:24:48.782Z</lastmod>
-    <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/OU8mJIOTr9U/sddefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[Don't Be Fooled By This $20,000 Robot]]></video:title>
-      <video:description><![CDATA[Marques Brownlee https://www.youtube.com/watch?v=j31dmodZ-5c
-Starforge PC https://starforgepc.com/moist-yt
-Get Goof Juice and use code MOIST https://gamersupps.gg/moist
-Our soap https://usecheeky.com/#starter-pack-offer
-Gaming channel https://www.youtube.com/@MoistCr1TiKaLGamingOfficial
-This is the greatest neo robot of All Time]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/OU8mJIOTr9U</video:player_loc>
-      <video:publication_date>2025-10-31T01:45:02.000Z</video:publication_date>
-    </video:video>
-  </url>
-  <url>
-    <loc>https://purereactions.com/reaction/fYxd94BCAZE1PTHOS5mi</loc>
-    <lastmod>2026-03-06T19:59:29.981Z</lastmod>
-    <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/ZbHRP5nfio0/maxresdefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[THIS WAS EPIC | PRETTY WHEN YOU BREAK | EKOH & CATCH YOUR BREATH]]></video:title>
-      <video:description><![CDATA[#ekoh #catchyourbreath #reaction #hiphophead #metalheadreacts #fyp 
-GET YOUR RIZZ HERE AND USE THE CODE (RR 15) AT CHECKOUT: https://rizzhydration.com/order-page?am_id=RykerRoad
+      <video:thumbnail_loc>https://i.ytimg.com/vi/YWI3y4LpouE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[A Truly Incredible Display Of Free Will...]]></video:title>
+      <video:description><![CDATA[#anginedepoitrine #sarniezz #reaction 
 
-Check out our PODCAST : https://www.youtube.com/@TheCaveCast
+In this video I'm checking out the viral @AnginePoitrine and their song "Sarniezz" (Live on KEXP)
 
-LISTEN TO THE CAVE CAST ON SPOTIFY AND MORE: https://rss.com/podcasts/the-cave-cast
+Original Video: https://www.youtube.com/watch?v=t7OIc-DBRXM
 
-NEED A PC? CHECK THIS OUT: https://romanhillspc.com/
+🤍Support On Patreon:
+https://www.patreon.com/DrewFortune
 
-EMAIL: rykerroad83@gmail.com
+🫂Join Discord Community:
+https://discord.gg/FP4kgrwyVc
 
-TWITCH: https://www.twitch.tv/rykerroad83
+🎦Follow My Twitch:
+https://www.twitch.tv/drewfortune1
 
-DISCORD: https://discord.gg/JksJFxCzdN
+📸Instagram:
+https://www.instagram.com/drewfortune?igsh=MWtmd3doNXhzMmFnYw%3D%3D&utm_source=qr
 
-FACEBOOK FAN PAGE: https://www.facebook.com/groups/1351062802203779/
+🕹️Clips + Gaming Channel:
+https://youtube.com/@DrewFortuneClips?si=6rP-yrbH_ROI1WDD
 
-MERCH: https://rykerroad-2024.itemorder.com/
+📩Business enquiries:
+DFBusinessEnquiries@gmail.com
 
-Want to send us fan mail?: 
+🥁Promote Your Band:
+https://www.drewfortune.com/services
 
-Rykerroad
-P.O. BOX 354
-Rittman, OH 44270
+Timestamps:
+00:00 Intro
+00:56 Reaction
+05:43 Who Are Angine De Poitrine?
 
-Gear:
-MICS: https://www.amazon.com/Shure-SM7B-Car...
-RODECASTER: https://www.amazon.com/s?k=rode+caste...
-TUBE LIGHTS: https://www.amazon.com/Photography-Pr...
-NEEWER LIGHTS: https://www.amazon.com/Neewer-Packs-D...
-
-PROGRAMS USED:
-Adobe Premiere Pro
-OBS Studio
-
-TIKTOK: @rykerroad
-PATREON: https://www.patreon.com/rykerroad
-Instagram: @rykerroad
-
-Kyle's YouTube: https://www.youtube.com/kylewright425
-Kyle's Instagram: https://www.instagram.com/kylewright425
-
-*Copyright Disclaimer under Section 107 of the copyright act 1976, allowance is made for fair use for purposes such as criticism, comment, news reporting, scholarship, and research. Fair use is a use permitted by copyright statute that might otherwise be infringing. Non-profit, educational or personal use tips the balance in favor of fair use. No copyright infringement intended. All rights belong to respective owners*]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/daLbKVAETu4</video:player_loc>
-      <video:duration>1335</video:duration>
-      <video:publication_date>2026-03-06T02:12:10.000Z</video:publication_date>
-    </video:video>
-  </url>
-  <url>
-    <loc>https://purereactions.com/reaction/nQpdziRL4J8Qmh4QJdKX</loc>
-    <lastmod>2026-01-25T15:24:49.135Z</lastmod>
-    <video:video>
-      <video:thumbnail_loc>https://i.ytimg.com/vi/onF-OAlDu48/maxresdefault.jpg</video:thumbnail_loc>
-      <video:title><![CDATA[Bilmuri - Blindsided - Pure Reactions]]></video:title>
-      <video:description><![CDATA[Watch the reaction alongside the original here: https://purereactions.com/reaction/nQpdziRL4J8Qmh4QJdKX]]></video:description>
-      <video:player_loc>https://www.youtube.com/embed/onF-OAlDu48</video:player_loc>
-      <video:publication_date>2024-04-23T12:55:31.000Z</video:publication_date>
+Sub Count As Of Upload: 151,402]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/YWI3y4LpouE</video:player_loc>
+      <video:duration>612</video:duration>
+      <video:publication_date>2026-04-10T17:43:46.000Z</video:publication_date>
     </video:video>
   </url>
   <url>
@@ -455,6 +703,259 @@ Just an attempt to make sense of the patterns — the attachment, the devotion, 
       <video:player_loc>https://www.youtube.com/embed/2FKBkSEdYQ8</video:player_loc>
       <video:duration>661</video:duration>
       <video:publication_date>2026-04-08T12:25:53.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/XbsHexRoxYNDqQk5Cmw9</loc>
+    <lastmod>2026-01-25T15:24:47.955Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/n1UszpQaxwI/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Pure Reactions - @2SICH - Let’s vibe y’all]]></video:title>
+      <video:description><![CDATA[Watch alongside the original here: https://purereactions.com/reaction/XbsHexRoxYNDqQk5Cmw9]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/n1UszpQaxwI</video:player_loc>
+      <video:publication_date>2024-04-30T20:42:07.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/XEpACZ7xtbyVDQ1ScvbG</loc>
+    <lastmod>2026-06-04T13:33:04.925Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/5-3S3pCJ0eE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[First Time Hearing Myles Smith! (TikTok Recommendation)]]></video:title>
+      <video:description><![CDATA[✨ Listen and watch the song with me on Pure Reactions: https://purereactions.com/reaction/XEpACZ7xtbyVDQ1ScvbG
+
+I asked TikTok for music recommendations, and you guys did not disappoint! In this video, I’m reacting to Miles Smith for the very first time. I had no idea what to expect, but wow... that "velvety" voice and those incredible vocal head-voice flips caught me completely off guard. 
+
+He gives off major Ed Sheeran feel-good pop vibes, and the message behind the touring music video is so wholesome. 
+
+Huge thank you to Laenge leve de frie for the recommendation! (Apologies if I completely mispronounced your name! 😂)
+
+What's your favorite Miles Smith song? Let me know in the comments what I should react to next!
+
+-----------------------------------------------------------------------
+⏳ TIMESTAMPS
+0:00 - Why I'm reacting to Miles Smith (TikTok recommendation)
+0:40 - The Song Starts
+0:55 - First Impressions & That Intro Vocal Flip!
+1:30 - Initial Reaction (Ed Sheeran vibes?)
+2:15 - Mid-song Thoughts (I guessed right!)
+5:15 - Final Review & The Meaning Behind the Music Video
+-----------------------------------------------------------------------
+
+My Tiktok : 
+
+#MilesSmith #Reaction #FirstTimeHearing #MusicReaction #EdSheeranVibes]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/5-3S3pCJ0eE</video:player_loc>
+      <video:duration>393</video:duration>
+      <video:publication_date>2026-06-04T13:00:08.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/xvNsmEsRPanhJCi3Pnan</loc>
+    <lastmod>2026-04-20T11:54:13.206Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/RBu3spAIjxo/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Senator Fought the Release of This Bodycam | xQc Reacts]]></video:title>
+      <video:description><![CDATA[video: https://youtu.be/ZrXIF2lYKcE
+Subscribe to my other Youtube channels for even more content! 
+xQc Reacts: https://bit.ly/3FJk2Il
+xQc Gaming: https://bit.ly/3DGwBSF
+
+Streaming every day on Twitch and Kick!
+https://twitch.tv/xqc
+https://kick.com/xqc
+
+Stay Connected with xQc:
+►Twitter: https://twitter.com/xqc
+►Reddit: https://www.reddit.com/r/xqcow/
+►Discord: https://discord.gg/xqcow
+►Instagram: https://instagram.com/xqcow1/
+►Snapchat: xqcow1
+
+If you own copyrighted material in this video and would like it removed please contact ► xqcyoutube@defiancemgmt.com]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/RBu3spAIjxo</video:player_loc>
+      <video:duration>1282</video:duration>
+      <video:publication_date>2025-08-09T13:00:52.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/yaI037na1t6lVsUcD3KA</loc>
+    <lastmod>2026-06-20T20:40:56.345Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/-Fv-WkNCGWE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V | COMEBACK REACTION!!!]]></video:title>
+      <video:description><![CDATA[More Content On Patreon!!!
+https://www.patreon.com/BRISxGANG
+
+GET YOUR MERCH HERE!!!
+https://teespring.com/stores/bris-2019-collection
+
+2ND CHANNEL: more BRISXLIFE
+https://www.youtube.com/channel/UCY7u8gGMB9S1Xm4tan_WyAQ
+
+SUBSCRIBE!!!
+https://www.youtube.com/channel/UCFdAdgyV43x3OolPd8RQUig
+-------------------------------------------------------------------------------------------------------------
+Check out my reaction to BLACKPINK - 'How You Like That' M/V | COMEBACK REACTION!!! 
+
+ORIGINAL VIDEO: https://www.youtube.com/watch?v=ioNng23DkIM
+__________________________________________________________________
+HIT ME UP!
+
+Follow my INSTAGRAM!
+https://www.instagram.com/brisxlife/
+
+Follow my TWITTER!
+https://twitter.com/BRISxLIFE
+----------------------------------------­----------------------------------------­------------------------------
+BUSINESS ONLY: BRISxLIFE@gmail.com
+--------------------------------------------------------------------------------------------------------------
+
+IF YOU WANT TO MAIL SOMETHING TO ME:
+P.O BOX 5573
+Buena Park, CA 90622]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/-Fv-WkNCGWE</video:player_loc>
+      <video:duration>455</video:duration>
+      <video:publication_date>2020-06-26T09:39:59.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reaction/ZZoCAht2hzYl7gjt5kI7</loc>
+    <lastmod>2026-01-25T15:24:48.334Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/nTNP_ef4O5w/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Pure Reactions - Worst Doctor Ever - @penguinz0]]></video:title>
+      <video:description><![CDATA[Watch the full reaction along with the original video side-by-side on my platform Pure Reactions (completely free) https://purereactions.com/reaction/ZZoCAht2hzYl7gjt5kI7/]]></video:description>
+      <video:player_loc>https://www.youtube.com/embed/nTNP_ef4O5w</video:player_loc>
+      <video:publication_date>2024-06-14T19:47:46.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reactions/blackpink-how-you-like-that-blackpink</loc>
+    <lastmod>2026-06-20T20:40:56.345Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/ioNng23DkIM/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[BLACKPINK - 'How You Like That' M/V]]></video:title>
+      <video:description><![CDATA[BLACKPINK - How You Like That
+
+보란 듯이 무너졌어
+바닥을 뚫고 저 지하까지
+옷 끝자락 잡겠다고
+저 높이 두 손을 뻗어봐도
+
+다시 캄캄한 이곳에 light up the sky
+네 두 눈을 보며 I’ll kiss you goodbye
+실컷 비웃어라 꼴좋으니까
+이제 너희 하나 둘 셋
+
+Ha how you like that?
+You gon’ like that that that that that
+How you like that?
+How you like that that that that that
+
+Now look at you now look at me
+Look at you now look at me 
+Look at you now look at me
+
+How you like that
+
+Now look at you now look at me
+Look at you now look at me 
+Look at you now look at me
+
+How you like that
+
+Your girl need it all and that’s a hundred
+백 개 중에 백 내 몫을 원해
+Karma come and get some 
+딱하지만 어쩔 수 없잖아
+What’s up, I’m right back
+방아쇠를 cock back
+Plain Jane get hijacked
+Don’t like me? Then tell me how you like that
+
+더 캄캄한 이곳에 shine like the stars
+그 미소를 띠며 I’ll kiss you goodbye
+
+실컷 비웃어라 꼴좋으니까 
+이제 너희 하나 둘 셋
+
+Ha how you like that?
+You gon’ like that that that that that
+How you like that?
+How you like that that that that that
+
+Now look at you now look at me
+Look at you now look at me 
+Look at you now look at me
+
+How you like that
+
+Now look at you now look at me
+Look at you now look at me 
+Look at you now look at me
+
+How you like that
+
+날개 잃은 채로 추락했던 날
+어두운 나날 속에 갇혀 있던 날
+그때쯤에 넌 날 끝내야 했어
+Look up in the sky it’s a bird it’s a plane
+
+Bring out your boss bish
+
+BLACKPINK!
+
+How you like that 
+You gon’ like that 
+How you like that 
+
+Available on @ https://smarturl.it/HowYouLikeThat
+
+More about BLACKPINK @
+http://www.blackpinkofficial.com/
+http://www.facebook.com/BLACKPINKOFFICIAL
+http://www.youtube.com/BLACKPINKOFFICIAL
+http://www.instagram.com/BLACKPINKOFFICIAL
+https://twitter.com/BLACKPINK
+
+#BLACKPINK #블랙핑크 #HowYouLikeThat #PreReleaseSingle #MV #20200626_6pm #OutNow #YG]]></video:description>
+      <video:player_loc>https://www.youtube.com/watch?v=ioNng23DkIM</video:player_loc>
+      <video:duration>184</video:duration>
+      <video:publication_date>2020-06-26T09:39:59.000Z</video:publication_date>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://purereactions.com/reactions/taylor-swift-the-fate-of-ophelia-taylorswift</loc>
+    <lastmod>2026-01-29T02:26:27.847Z</lastmod>
+    <video:video>
+      <video:thumbnail_loc>https://i.ytimg.com/vi/ko70cExuzZM/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title><![CDATA[Taylor Swift - The Fate of Ophelia (Official Music Video)]]></video:title>
+      <video:description><![CDATA[The official music video for “The Fate of Ophelia”
+
+Stream/download ‘The Life of a Showgirl’: https://taylor.lnk.to/TSTheLifeofaShowgirl
+
+►Subscribe to Taylor Swift on YouTube: https://ts.lnk.to/subscribe
+►Shop Merch: http://taylor.lnk.to/store 
+►Follow Taylor Swift Online: 
+TikTok: http://tiktok.com/@taylorswift 
+Instagram: http://instagram.com/taylorswift 
+Twitter: http://twitter.com/taylorswift13 
+Snapchat: http://snapchat.com/add/taylorswift 
+Facebook: http://facebook.com/taylorswift 
+Tumblr: http://taylorswift.tumblr.com 
+Website: http://www.taylorswift.com 
+
+►Follow Taylor Nation Online 
+TikTok: http://tiktok.com/@taylornation
+ Instagram: http://instagram.com/taylornation 
+YouTube: https://youtube.com/taylornation 
+Twitter: http://twitter.com/taylornation13
+ Tumblr: http://taylornation.tumblr.com
+
+#TaylorSwift #TheLifeofaShowgirl #TheFateofOphelia]]></video:description>
+      <video:player_loc>https://www.youtube.com/watch?v=ko70cExuzZM</video:player_loc>
+      <video:publication_date>2025-10-05T23:00:06.000Z</video:publication_date>
     </video:video>
   </url>
 </urlset>

--- a/tests/integration/generate-sitemap.test.js
+++ b/tests/integration/generate-sitemap.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOriginalVideoSitemapEntries,
+  buildReactionSitemapEntries
+} from '../../scripts/generate-sitemap.js';
+
+function makeReaction(id, originalVideoId, originalVideoSlug, overrides = {}) {
+  return {
+    id,
+    data: {
+      originalVideoId,
+      originalVideoSlug,
+      originalVideoTitle: overrides.originalVideoTitle ?? `Original ${originalVideoId}`,
+      originalVideoDescription: overrides.originalVideoDescription ?? `Description for ${originalVideoId}`,
+      originalVideoThumbnailUrl: overrides.originalVideoThumbnailUrl ?? `https://cdn.example/${originalVideoId}.jpg`,
+      originalVideoUrl: overrides.originalVideoUrl ?? `https://www.youtube.com/watch?v=${originalVideoId}`,
+      createdAt: overrides.createdAt ?? '2025-01-01T00:00:00.000Z',
+      updatedAt: overrides.updatedAt ?? '2025-01-02T00:00:00.000Z',
+      isPublished: true,
+      ...overrides
+    }
+  };
+}
+
+describe('buildOriginalVideoSitemapEntries', () => {
+  it('emits one canonical /reactions/[slug] entry per original video with at least two published reactions', () => {
+    const reactions = [
+      makeReaction('reaction-a1', 'original-a', 'alpha-video-creator-a'),
+      makeReaction('reaction-a2', 'original-a', 'alpha-video-creator-a', {
+        updatedAt: '2025-01-03T00:00:00.000Z'
+      }),
+      makeReaction('reaction-b1', 'original-b', 'bravo-video-creator-b'),
+      makeReaction('reaction-b2', 'original-b', 'bravo-video-creator-b'),
+      makeReaction('reaction-b3', 'original-b', 'bravo-video-creator-b', {
+        updatedAt: '2025-01-04T00:00:00.000Z'
+      }),
+      makeReaction('reaction-c1', 'original-c', 'charlie-video-creator-c')
+    ];
+
+    const entries = buildOriginalVideoSitemapEntries(reactions, 'https://purereactions.com');
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.originalVideoId)).toEqual(['original-a', 'original-b']);
+    expect(entries.map((entry) => entry.slug)).toEqual([
+      'alpha-video-creator-a',
+      'bravo-video-creator-b'
+    ]);
+    expect(entries.map((entry) => entry.loc)).toEqual([
+      'https://purereactions.com/reactions/alpha-video-creator-a',
+      'https://purereactions.com/reactions/bravo-video-creator-b'
+    ]);
+    expect(entries[0].lines).toContain(
+      '<loc>https://purereactions.com/reactions/alpha-video-creator-a</loc>'
+    );
+    expect(entries[1].lines).toContain(
+      '<loc>https://purereactions.com/reactions/bravo-video-creator-b</loc>'
+    );
+    expect(entries[0].lines).not.toContain('charlie-video-creator-c');
+  });
+
+  it('keeps the existing per-reaction sitemap entries', () => {
+    const reactions = [
+      makeReaction('reaction-a1', 'original-a', 'alpha-video-creator-a'),
+      makeReaction('reaction-b1', 'original-b', 'bravo-video-creator-b')
+    ];
+
+    const entries = buildReactionSitemapEntries(reactions, 'https://purereactions.com');
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.loc)).toEqual([
+      'https://purereactions.com/reaction/reaction-a1',
+      'https://purereactions.com/reaction/reaction-b1'
+    ]);
+  });
+});


### PR DESCRIPTION
Refactor scripts/generate-sitemap.js to split reaction entries and canonical original-video collection entries. Introduce helper functions (pickOriginalVideoThumbnail, pickOriginalVideoDurationSeconds, pickBestReactionForMetadata), buildReactionSitemapEntries, buildOriginalVideoSitemapEntries, fetchPublishedReactions, and buildReactionSitemapEntry; use a canonical base URL and conditional direct-execution guard (pathToFileURL). Export key helpers for testing. Update static/sitemap.xml content (new entries) and add an integration test (tests/integration/generate-sitemap.test.js) to validate original-video sitemap entry generation and preservation of per-reaction entries.